### PR TITLE
Be able to overwrite supermaster_query

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ The host where your database should be created. Defaults to 'localhost'.
 
 Don't manage repo with this module. Defaults to false.
 
+##### `supermaster_query`
+
+Set query to select supermasters. Defaults to 'select account from supermasters where ip=\'%s\''.
+
 ### Defines
 
 #### powerdns::config

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,15 +1,16 @@
 # powerdns
 class powerdns (
-    $authorative      = $::powerdns::params::authorative,
-    $recursor         = $::powerdns::params::recursor,
-    $backend          = $::powerdns::params::backend,
-    $backend_install  = $::powerdns::params::backend_install,
-    $db_root_password = $::powerdns::params::db_root_password,
-    $db_username      = $::powerdns::params::db_username,
-    $db_password      = $::powerdns::params::db_password,
-    $db_name          = $::powerdns::params::db_name,
-    $db_host          = $::powerdns::params::db_host,
-    $custom_repo      = $::powerdns::params::custom_repo,
+    $authorative       = $::powerdns::params::authorative,
+    $recursor          = $::powerdns::params::recursor,
+    $backend           = $::powerdns::params::backend,
+    $backend_install   = $::powerdns::params::backend_install,
+    $db_root_password  = $::powerdns::params::db_root_password,
+    $db_username       = $::powerdns::params::db_username,
+    $db_password       = $::powerdns::params::db_password,
+    $db_name           = $::powerdns::params::db_name,
+    $db_host           = $::powerdns::params::db_host,
+    $custom_repo       = $::powerdns::params::custom_repo,
+    $supermaster_query = $::powerdns::params::supermaster_query,
   ) inherits powerdns::params {
 
   # do some basic checks


### PR DESCRIPTION
I need to overwrite it to 'select account from supermasters where ip=\'%s\' and nameserver=\'%s\'' to make it work for version 4.0.1