### PR TITLE
Only try to set config if we want to the corresponding services

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,20 +26,20 @@ class powerdns (
 
   if $authoritative == true {
     include ::powerdns::authoritative
+
+    # Set up Hiera. Even though it's not necessary to explicitly set $type for the authoritative
+    # config, it is added for clarity.
+    $powerdns_auth_config = hiera('powerdns::auth::config', {})
+    $powerdns_auth_defaults = { 'type' => 'authoritative' }
+    create_resources(powerdns::config, $powerdns_auth_config, $powerdns_auth_defaults)
   }
 
   if $recursor == true {
     include ::powerdns::recursor
+
+    # Set up Hiera for the recursor.
+    $powerdns_recursor_config = hiera('powerdns::recursor::config', {})
+    $powerdns_recursor_defaults = { 'type' => 'recursor' }
+    create_resources(powerdns::config, $powerdns_recursor_config, $powerdns_recursor_defaults)
   }
-
-  # Set up Hiera. Even though it's not necessary to explicitly set $type for the authoritative
-  # config, it is added for clarity.
-  $powerdns_auth_config = hiera('powerdns::auth::config', {})
-  $powerdns_auth_defaults = { 'type' => 'authoritative' }
-  create_resources(powerdns::config, $powerdns_auth_config, $powerdns_auth_defaults)
-
-  # Set up Hiera for the recursor.
-  $powerdns_recursor_config = hiera('powerdns::recursor::config', {})
-  $powerdns_recursor_defaults = { 'type' => 'recursor' }
-  create_resources(powerdns::config, $powerdns_recursor_config, $powerdns_recursor_defaults)
 }


### PR DESCRIPTION
If you setup in hiera recursor config which is also read by an authoritive only node it fails to apply it.
```
Could not retrieve catalog from remote server: Error 400 on SERVER: Invalid relationship: File_line[powerdns-config-forward-zones-example.net=1.2.3.253-/etc/powerdns/recursor.conf] { before => Service[pdns-recursor] }, because Service[pdns-recursor] doesn't seem to be in the catalog
```
So let's look it up only if we want to.