### PR TITLE
Change basic check to look at backend_install

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,7 +14,9 @@ class powerdns (
 
   # do some basic checks
   if $authoritative == true {
-    if $db_root_password == '' { fail("Database root password can't be empty") }
+    if $backend_install == true {
+      if $db_root_password == '' { fail("Database root password can't be empty") }
+    }
     if $db_username == '' { fail("Database username can't be empty") }
     if $db_password == '' { fail("Database password can't be empty") }
   }


### PR DESCRIPTION
Documentation (and expected results) specify that db_root_password is
required if backend_install is true. Modify init.pp to only fail if
authoritative AND backend_install is true.

This is in reference to #10 