### PR TITLE
Enable service on boot

### DIFF
--- a/manifests/authoritative.pp
+++ b/manifests/authoritative.pp
@@ -16,6 +16,7 @@ class powerdns::authoritative ($package_ensure = $powerdns::params::default_pack
   }
 
   service { $::powerdns::params::authoritative_service:
+    enable  => true,
     ensure  => running,
     require => Package[$::powerdns::params::authoritative_package],
   }

--- a/manifests/recursor.pp
+++ b/manifests/recursor.pp
@@ -5,6 +5,7 @@ class powerdns::recursor ($package_ensure = $powerdns::params::default_package_e
   }
 
   service { $::powerdns::params::recursor_service:
+    enable  => true,
     ensure  => running,
     require => Package[$::powerdns::params::recursor_package],
   }


### PR DESCRIPTION
Hi @sensson 

To start, thanks for you module ! Really easy to use and manage.

We have a small issue with the module.
The service don't start on boot.

You set the service in 2 differents class:
- powerdns/manifests/recursor.pp
- powerdns/manifests/authoritative.pp

As we don't want to change parameters inside your class in case of an upgrade which will override our settings, can you add the parameter "enable => true", to ensure the service in starting when the machine have boot ?


Thanks a lot for your work !
Mouglou