### PR TITLE
Support purging config settings

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,33 +1,28 @@
 # powerdns::config
 define powerdns::config(
-  $setting = $title,
-  $value   = '',
-  $ensure  = 'present',
-  $type    = 'authoritative'
+  String                            $setting = $title,
+  String                            $value   = '',
+  Enum['present', 'absent']         $ensure  = 'present',
+  Enum['authoritative', 'recursor'] $type    = 'authoritative'
 ) {
 
-  unless $ensure == 'absent' {
-    if $value == '' and ! ($setting in [ 'gmysql-dnssec', 'only-notify' ]) { fail("Value for ${setting} can't be empty.") }
+  unless $ensure == 'absent' or ($setting in [ 'gmysql-dnssec', 'only-notify' ]) {
+    assert_type(String[1], $value) |$_expected, $_actual| {
+      fail("Value for ${setting} can't be empty.")
+    }
   }
 
   if $setting == 'gmysql-dnssec' { $line = $setting }
   else { $line = "${setting}=${value}" }
 
-  case $type {
-    'authoritative': {
-      $path = $::powerdns::params::authoritative_config
-      $require_package = $::powerdns::params::authoritative_package
-      $notify_service = $::powerdns::params::authoritative_service
-    }
-    'recursor': {
-      $path = $::powerdns::params::recursor_config
-      $require_package = $::powerdns::params::recursor_package
-      $notify_service = $::powerdns::params::recursor_service
-    }
-
-    default: {
-      fail("${type} is not supported as config type.")
-    }
+  if $type == 'authoritative' {
+    $path            = $::powerdns::params::authoritative_config
+    $require_package = $::powerdns::params::authoritative_package
+    $notify_service  = $::powerdns::params::authoritative_service
+  } else {
+    $path            = $::powerdns::params::recursor_config
+    $require_package = $::powerdns::params::recursor_package
+    $notify_service  = $::powerdns::params::recursor_service
   }
 
   file_line { "powerdns-config-${setting}-${path}":
@@ -38,6 +33,5 @@ define powerdns::config(
     match_for_absence => true, # ignored when ensure == 'present'
     require           => Package[$require_package],
     notify            => Service[$notify_service],
-    before            => Service[$notify_service],
   }
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,7 +6,10 @@ define powerdns::config(
   $type    = 'authoritative'
 ) {
 
-  if $value == '' and ! ($setting in [ 'gmysql-dnssec', 'only-notify' ]) { fail("Value for ${setting} can't be empty.") }
+  unless $ensure == 'absent' {
+    if $value == '' and ! ($setting in [ 'gmysql-dnssec', 'only-notify' ]) { fail("Value for ${setting} can't be empty.") }
+  }
+
   if $setting == 'gmysql-dnssec' { $line = $setting }
   else { $line = "${setting}=${value}" }
 
@@ -28,12 +31,13 @@ define powerdns::config(
   }
 
   file_line { "powerdns-config-${setting}-${path}":
-    ensure  => $ensure,
-    path    => $path,
-    line    => $line,
-    match   => "^${setting}=",
-    require => Package[$require_package],
-    notify  => Service[$notify_service],
-    before  => Service[$notify_service],
+    ensure            => $ensure,
+    path              => $path,
+    line              => $line,
+    match             => "^${setting}=",
+    match_for_absence => true, # ignored when ensure == 'present'
+    require           => Package[$require_package],
+    notify            => Service[$notify_service],
+    before            => Service[$notify_service],
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -13,6 +13,9 @@
         { "operatingsystem": "Ubuntu", "operatingsystemrelease": [ "14.04", "16.04" ] },
         { "operatingsystem": "Debian", "operatingsystemrelease": [ "8" ] }
     ],
+    "requirements": [
+        { "name": "puppet", "version_requirement": ">= 4.7.0 < 6.0.0" }
+    ],
     "dependencies": [
         { "name": "puppetlabs/stdlib", "version_requirement": ">=4.3.2 < 5.0.0" },
         { "name": "puppetlabs/mysql", "version_requirement": ">=3.4.0 < 4.0.0" },

--- a/spec/defines/powerdns_config_spec.rb
+++ b/spec/defines/powerdns_config_spec.rb
@@ -49,6 +49,7 @@ describe 'powerdns::config' do
           it { is_expected.to contain_file_line(format('powerdns-config-foo-%<config>s', config: authoritative_config)).with_path(authoritative_config) }
           it { is_expected.to contain_file_line(format('powerdns-config-foo-%<config>s', config: authoritative_config)).with_line('foo=bar') }
           it { is_expected.to contain_file_line(format('powerdns-config-foo-%<config>s', config: authoritative_config)).with_match('^foo=') }
+          it { is_expected.to contain_file_line(format('powerdns-config-foo-%<config>s', config: authoritative_config)).with_match_for_absence(true) }
           it { is_expected.to contain_file_line(format('powerdns-config-foo-%<config>s', config: authoritative_config)).that_notifies(format('Service[%<service>s]', service: authoritative_service_name)) }
         end
 
@@ -95,6 +96,17 @@ describe 'powerdns::config' do
           it 'fails' do
             expect { subject.call } .to raise_error(/Value for empty can't be empty./)
           end
+        end
+
+        context 'powerdns::config with empty value and ensure == absent' do
+          let(:params) do
+            {
+              ensure: 'absent',
+              setting: 'foo'
+            }
+          end
+
+          it { is_expected.to contain_file_line(format('powerdns-config-foo-%<config>s', config: authoritative_config)) }
         end
 
         # Test incorrect service type

--- a/spec/defines/powerdns_config_spec.rb
+++ b/spec/defines/powerdns_config_spec.rb
@@ -120,7 +120,7 @@ describe 'powerdns::config' do
           end
 
           it 'fails' do
-            expect { subject.call } .to raise_error(/is not supported as config type/)
+            expect { subject.call } .to raise_error(/expects a match for Enum\['authoritative', 'recursor'\], got/)
           end
         end
       end


### PR DESCRIPTION
Support removing config with `ensure => absent`.  In a separate commit I've converted the class to use puppet 4 style parameter validation.