### PR TITLE
Contain subclasses in init.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,11 +26,11 @@ class powerdns (
 
   # Include the required classes
   unless $custom_repo {
-    include ::powerdns::repo
+    contain powerdns::repo
   }
 
   if $authoritative {
-    include ::powerdns::authoritative
+    contain powerdns::authoritative
 
     # Set up Hiera. Even though it's not necessary to explicitly set $type for the authoritative
     # config, it is added for clarity.
@@ -40,7 +40,7 @@ class powerdns (
   }
 
   if $recursor {
-    include ::powerdns::recursor
+    contain powerdns::recursor
 
     # Set up Hiera for the recursor.
     $powerdns_recursor_config = hiera('powerdns::recursor::config', {})


### PR DESCRIPTION
The 'private' subclasses should really be contained to help with
ordering.

eg I was doing something a bit like...

```puppet

pulp_rpmbind{'powerdns-4.1':}

class { 'powerdns':
  custom_repo => true,
  require     => Pulp_rpmbind['powerdns-4.1'],
  ...
}
```

But since powerdns::authoritative wasn't 'contained' in init.pp the
ordering I was trying to enforce didn't work as expected.  I ended up
with powerdns installed from EPEL.