### PR TITLE
Add backend_create_tables parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,13 @@ Choose a backend for the authoritative server. Valid values are 'mysql'. Default
 ##### `backend_install`
 
 If you set this to true it will try to install a database backend for
-you. This requires `db_root_password`, `db_username`, `db_password`,
-`db_name` and `db_host` to be set. Defaults to true.
+you. This requires `db_root_password`. Defaults to true.
+
+##### `backend_create_tables`
+
+If set to true, it will ensure the required powerdns tables exist in your backend database.
+If your database is on a separate host, set `backend_install` and `backend_create_tables` to false.
+Defaults to true.
 
 ##### `db_root_password`
 

--- a/manifests/backends/mysql.pp
+++ b/manifests/backends/mysql.pp
@@ -50,47 +50,49 @@ class powerdns::backends::mysql inherits powerdns {
     }
   }
 
-  # make sure the database exists
-  mysql::db { $::powerdns::db_name:
-    user     => $::powerdns::db_username,
-    password => $::powerdns::db_password,
-    host     => $::powerdns::db_host,
-    grant    => [ 'ALL' ],
-  }
+  if $::powerdns::backend_create_tables {
+    # make sure the database exists
+    mysql::db { $::powerdns::db_name:
+      user     => $::powerdns::db_username,
+      password => $::powerdns::db_password,
+      host     => $::powerdns::db_host,
+      grant    => [ 'ALL' ],
+    }
 
-  # create tables
-  powerdns::backends::mysql::create_table { 'domains':
-    database => $::powerdns::db_name,
-    create   => template('powerdns/domains.sql.erb'),
-  }
+    # create tables
+    powerdns::backends::mysql::create_table { 'domains':
+      database => $::powerdns::db_name,
+      create   => template('powerdns/domains.sql.erb'),
+    }
 
-  powerdns::backends::mysql::create_table { 'records':
-    database => $::powerdns::db_name,
-    create   => template('powerdns/records.sql.erb'),
-  }
+    powerdns::backends::mysql::create_table { 'records':
+      database => $::powerdns::db_name,
+      create   => template('powerdns/records.sql.erb'),
+    }
 
-  powerdns::backends::mysql::create_table { 'supermasters':
-    database => $::powerdns::db_name,
-    create   => template('powerdns/supermasters.sql.erb'),
-  }
+    powerdns::backends::mysql::create_table { 'supermasters':
+      database => $::powerdns::db_name,
+      create   => template('powerdns/supermasters.sql.erb'),
+    }
 
-  powerdns::backends::mysql::create_table { 'domainmetadata':
-    database => $::powerdns::db_name,
-    create   => template('powerdns/domainmetadata.sql.erb'),
-  }
+    powerdns::backends::mysql::create_table { 'domainmetadata':
+      database => $::powerdns::db_name,
+      create   => template('powerdns/domainmetadata.sql.erb'),
+    }
 
-  powerdns::backends::mysql::create_table { 'cryptokeys':
-    database => $::powerdns::db_name,
-    create   => template('powerdns/cryptokeys.sql.erb'),
-  }
+    powerdns::backends::mysql::create_table { 'cryptokeys':
+      database => $::powerdns::db_name,
+      create   => template('powerdns/cryptokeys.sql.erb'),
+    }
 
-  powerdns::backends::mysql::create_table { 'comments':
-    database => $::powerdns::db_name,
-    create   => template('powerdns/comments.sql.erb'),
-  }
+    powerdns::backends::mysql::create_table { 'comments':
+      database => $::powerdns::db_name,
+      create   => template('powerdns/comments.sql.erb'),
+    }
 
-  powerdns::backends::mysql::create_table { 'tsigkeys':
-    database => $::powerdns::db_name,
-    create   => template('powerdns/tsigkeys.sql.erb'),
+    powerdns::backends::mysql::create_table { 'tsigkeys':
+      database => $::powerdns::db_name,
+      create   => template('powerdns/tsigkeys.sql.erb'),
+    }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,15 +1,16 @@
 # powerdns
 class powerdns (
-    Boolean             $authoritative    = $::powerdns::params::authoritative,
-    Boolean             $recursor         = $::powerdns::params::recursor,
-    Enum['mysql']       $backend          = $::powerdns::params::backend,
-    Boolean             $backend_install  = $::powerdns::params::backend_install,
-    Optional[String[1]] $db_root_password = $::powerdns::params::db_root_password,
-    String[1]           $db_username      = $::powerdns::params::db_username,
-    Optional[String[1]] $db_password      = $::powerdns::params::db_password,
-    String[1]           $db_name          = $::powerdns::params::db_name,
-    String[1]           $db_host          = $::powerdns::params::db_host,
-    Boolean             $custom_repo      = $::powerdns::params::custom_repo,
+    Boolean             $authoritative         = $::powerdns::params::authoritative,
+    Boolean             $recursor              = $::powerdns::params::recursor,
+    Enum['mysql']       $backend               = $::powerdns::params::backend,
+    Boolean             $backend_install       = $::powerdns::params::backend_install,
+    Boolean             $backend_create_tables = $::powerdns::params::backend_create_tables,
+    Optional[String[1]] $db_root_password      = $::powerdns::params::db_root_password,
+    String[1]           $db_username           = $::powerdns::params::db_username,
+    Optional[String[1]] $db_password           = $::powerdns::params::db_password,
+    String[1]           $db_name               = $::powerdns::params::db_name,
+    String[1]           $db_host               = $::powerdns::params::db_host,
+    Boolean             $custom_repo           = $::powerdns::params::custom_repo,
   ) inherits powerdns::params {
 
   # Do some additional checks. In certain cases, some parameters are no longer optional.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,6 +4,7 @@ class powerdns::params {
   $recursor = false
   $backend = 'mysql'
   $backend_install = true
+  $backend_create_tables = true
   $db_root_password = undef
   $db_username = 'powerdns'
   $db_password = undef

--- a/spec/classes/powerdns_init_spec.rb
+++ b/spec/classes/powerdns_init_spec.rb
@@ -120,6 +120,29 @@ describe 'powerdns', type: :class do
           it { is_expected.to contain_file_line(format('powerdns-config-launch-%<config>s', config: authoritative_config)) }
         end
 
+        context 'powerdns class with backend_create_tables set to false' do
+          let(:params) do
+            {
+              db_root_password: 'foobar',
+              db_username: 'foo',
+              db_password: 'bar',
+              backend: 'mysql',
+              backend_create_tables: false
+            }
+          end
+
+          # Tables aren't created and neither is the database
+          it { is_expected.not_to contain_mysql__db('powerdns').with('user' => 'foo', 'password' => 'bar', 'host' => 'localhost') }
+
+          it { is_expected.not_to contain_powerdns__backends__mysql__create_table('comments') }
+          it { is_expected.not_to contain_powerdns__backends__mysql__create_table('cryptokeys') }
+          it { is_expected.not_to contain_powerdns__backends__mysql__create_table('domainmetadata') }
+          it { is_expected.not_to contain_powerdns__backends__mysql__create_table('domains') }
+          it { is_expected.not_to contain_powerdns__backends__mysql__create_table('records') }
+          it { is_expected.not_to contain_powerdns__backends__mysql__create_table('supermasters') }
+          it { is_expected.not_to contain_powerdns__backends__mysql__create_table('tsigkeys') }
+        end
+
         # Test the recursor
         context 'powerdns class with the recursor enabled and the authoritative server disabled' do
           let(:params) do


### PR DESCRIPTION
When set to false, the backend tables won't be managed.
Defaults to true so is backwards compatible.

This is useful if your database is on another host.  It will
also make adding basic postgresql support easier.