### PR TITLE
Oracle Linux Support, Removing yum-plugin-priorities

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ This module has been tested on:
 * Ubuntu 14.04
 * Ubuntu 16.04
 * Debian 8
+* Oracle Linux 7
 
 ## Development
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,7 +13,7 @@ class powerdns::params {
   $default_package_ensure = installed
 
   case $::operatingsystem {
-    'centos': {
+    'centos', 'OracleLinux': {
       $authoritative_package = 'pdns'
       $authoritative_service = 'pdns'
       $authoritative_config = '/etc/pdns/pdns.conf'

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,7 +1,7 @@
 # powerdns::repo
 class powerdns::repo {
   case $::operatingsystem {
-    'centos': {
+    'centos', 'OracleLinux': {
       Yumrepo['powerdns'] -> Package <| title == $::powerdns::params::authoritative_package |>
       Yumrepo['powerdns-recursor'] -> Package <| title == $::powerdns::params::recursor_package |>
 

--- a/spec/classes/powerdns_init_spec.rb
+++ b/spec/classes/powerdns_init_spec.rb
@@ -28,7 +28,7 @@ describe 'powerdns', type: :class do
 
         context 'powerdns class without parameters' do
           it 'fails' do
-            expect { subject.call } .to raise_error(/Database root password can't be empty/)
+            expect { subject.call } .to raise_error(/'db_password' must be a non-empty string when 'authoritative' == true/)
           end
         end
 
@@ -154,7 +154,7 @@ describe 'powerdns', type: :class do
           end
 
           it 'fails' do
-            expect { subject.call } .to raise_error(/Database username can't be empty/)
+            expect { subject.call } .to raise_error(/parameter 'db_username' expects a String\[1, default\] value, got String/)
           end
         end
 
@@ -167,7 +167,7 @@ describe 'powerdns', type: :class do
           end
 
           it 'fails' do
-            expect { subject.call } .to raise_error(/Database password can't be empty/)
+            expect { subject.call } .to raise_error(/'db_password' must be a non-empty string when 'authoritative' == true/)
           end
         end
 
@@ -182,7 +182,7 @@ describe 'powerdns', type: :class do
           end
 
           it 'fails' do
-            expect { subject.call } .to raise_error(/is not supported/)
+            expect { subject.call } .to raise_error(/'backend' expects a match for Enum\['mysql'\]/)
           end
         end
       end


### PR DESCRIPTION
Included OracleLinux as an OS option. Removed yum-plugin-priorities package as it doesn't have anything to do with installing PowerDNS 4

Also installing the yum-plugin-priorities package including a before argument, gets into a fight with my baseline module.