### PR TITLE
Support other RedHat flavours

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,13 @@ This module has been tested on:
 * Ubuntu 14.04
 * Ubuntu 16.04
 * Debian 8
+* Oracle Linux 7
+
+We believe it also works on:
+
+* Oracle Linux 6
+* RedHat Enterprise Linux 6 & 7
+* Scientific Linux 6 & 7
 
 ## Development
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,8 +13,8 @@ class powerdns::params {
   $custom_repo = false
   $default_package_ensure = installed
 
-  case $::operatingsystem {
-    'centos': {
+  case $facts['os']['family'] {
+    'RedHat': {
       $authoritative_package = 'pdns'
       $authoritative_service = 'pdns'
       $authoritative_config = '/etc/pdns/pdns.conf'
@@ -22,7 +22,7 @@ class powerdns::params {
       $recursor_service = 'pdns-recursor'
       $recursor_config = '/etc/pdns-recursor/recursor.conf'
     }
-    'ubuntu', 'debian': {
+    'Debian': {
       $authoritative_package = 'pdns-server'
       $authoritative_service = 'pdns'
       $authoritative_config = '/etc/powerdns/pdns.conf'
@@ -31,7 +31,7 @@ class powerdns::params {
       $recursor_config = '/etc/powerdns/recursor.conf'
     }
     default: {
-      fail("${::operatingsystem} is not supported yet.")
+      fail("${facts['os']['family']} is not supported yet.")
     }
   }
 }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,7 +1,7 @@
 # powerdns::repo
 class powerdns::repo {
-  case $::operatingsystem {
-    'centos': {
+  case $facts['os']['family'] {
+    'RedHat': {
       Yumrepo['powerdns'] -> Package <| title == $::powerdns::params::authoritative_package |>
       Yumrepo['powerdns-recursor'] -> Package <| title == $::powerdns::params::recursor_package |>
 
@@ -33,10 +33,10 @@ class powerdns::repo {
       }
     }
 
-    'ubuntu', 'debian': {
+    'Debian': {
       include ::apt
 
-      $os = downcase($::operatingsystem)
+      $os = downcase($facts['os']['name'])
 
       # Make sure the repo's are added before we're managing packages
       # puppet-lint seems to error out on spaces here (bug?) so it looks a bit dodgy
@@ -75,7 +75,7 @@ class powerdns::repo {
     }
 
     default: {
-      fail("${::operatingsystem} is not supported yet.")
+      fail("${facts['os']['family']} is not supported yet.")
     }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,10 @@
     "issues_url": "https://github.com/sensson/puppet-powerdns/issues",
     "tags": [ "powerdns" ],
     "operatingsystem_support": [
-        { "operatingsystem": "CentOS", "operatingsystemrelease": [ "6", "7" ] },
+        { "operatingsystem": "CentOS",      "operatingsystemrelease": [ "6", "7" ] },
+        { "operatingsystem": "OracleLinux", "operatingsystemrelease": [ "6", "7" ] },
+        { "operatingsystem": "RedHat",      "operatingsystemrelease": [ "6", "7" ] },
+        { "operatingsystem": "Scientific",  "operatingsystemrelease": [ "6", "7" ] },
         { "operatingsystem": "Ubuntu", "operatingsystemrelease": [ "14.04", "16.04" ] },
         { "operatingsystem": "Debian", "operatingsystemrelease": [ "8" ] }
     ],


### PR DESCRIPTION
Instead of supporting just CentOS, support all RedHat family OSes.