### PR TITLE
Add basic LDAP backend support

### DIFF
--- a/manifests/authoritative.pp
+++ b/manifests/authoritative.pp
@@ -16,8 +16,11 @@ class powerdns::authoritative ($package_ensure = $powerdns::params::default_pack
     'postgresql': {
       include powerdns::backends::postgresql
     }
+    'ldap': {
+      include powerdns::backends::ldap
+    }
     default: {
-      fail("${::powerdns::backend} is not supported. We only support 'mysql', 'bind' and 'postgresql' at the moment.")
+      fail("${::powerdns::backend} is not supported. We only support 'mysql', 'bind', 'postgresql' and 'ldap' at the moment.")
     }
   }
 

--- a/manifests/backends/ldap.pp
+++ b/manifests/backends/ldap.pp
@@ -12,28 +12,28 @@ class powerdns::backends::ldap inherits powerdns {
   powerdns::config { 'ldap-host':
     ensure  => present,
     setting => 'ldap-host',
-    value   => $::powerdns::db_host,
+    value   => $::powerdns::ldap_host,
     type    => 'authoritative',
   }
 
   powerdns::config { 'ldap-binddn':
     ensure  => present,
     setting => 'ldap-binddn',
-    value   => $::powerdns::db_username,
+    value   => $::powerdns::ldap_binddn,
     type    => 'authoritative',
   }
 
   powerdns::config { 'ldap-secret':
     ensure  => present,
     setting => 'ldap-secret',
-    value   => $::powerdns::db_password,
+    value   => $::powerdns::ldap_secret,
     type    => 'authoritative',
   }
 
   powerdns::config { 'ldap-basedn':
     ensure  => present,
     setting => 'ldap-basedn',
-    value   => $::powerdns::db_name,
+    value   => $::powerdns::ldap_basedn,
     type    => 'authoritative',
   }
 

--- a/manifests/backends/ldap.pp
+++ b/manifests/backends/ldap.pp
@@ -1,0 +1,61 @@
+# ldap backend for powerdns
+class powerdns::backends::ldap inherits powerdns {
+
+  # set the configuration variables
+  powerdns::config { 'launch':
+    ensure  => present,
+    setting => 'launch',
+    value   => 'ldap',
+    type    => 'authoritative',
+  }
+
+  powerdns::config { 'ldap-host':
+    ensure  => present,
+    setting => 'ldap-host',
+    value   => $::powerdns::db_host,
+    type    => 'authoritative',
+  }
+
+  powerdns::config { 'ldap-binddn':
+    ensure  => present,
+    setting => 'ldap-binddn',
+    value   => $::powerdns::db_username,
+    type    => 'authoritative',
+  }
+
+  powerdns::config { 'ldap-secret':
+    ensure  => present,
+    setting => 'ldap-secret',
+    value   => $::powerdns::db_password,
+    type    => 'authoritative',
+  }
+
+  powerdns::config { 'ldap-basedn':
+    ensure  => present,
+    setting => 'ldap-basedn',
+    value   => $::powerdns::db_name,
+    type    => 'authoritative',
+  }
+
+  powerdns::config { 'ldap-method':
+    ensure  => present,
+    setting => 'ldap-method',
+    value   => $::powerdns::ldap_method,
+    type    => 'authoritative',
+  }
+
+  # set up the powerdns backend
+  package { $::powerdns::params::ldap_backend_package_name:
+    ensure  => installed,
+    before  => Service[$::powerdns::params::authoritative_service],
+    require => Package[$::powerdns::params::authoritative_package],
+  }
+
+  if $::powerdns::backend_install {
+    fail('backend_install is not supported with ldap')
+  }
+
+  if $::powerdns::backend_create_tables {
+    fail('backend_create_tables is not supported with ldap')
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,19 +1,19 @@
 # powerdns
 class powerdns (
-  Boolean                    $authoritative         = $::powerdns::params::authoritative,
-  Boolean                    $recursor              = $::powerdns::params::recursor,
-  Enum['mysql', 'bind', 'postgresql'] $backend      = $::powerdns::params::backend,
-  Boolean                    $backend_install       = $::powerdns::params::backend_install,
-  Boolean                    $backend_create_tables = $::powerdns::params::backend_create_tables,
-  Optional[String[1]]        $db_root_password      = $::powerdns::params::db_root_password,
-  Optional[String[1]]        $db_username           = $::powerdns::params::db_username,
-  Optional[String[1]]        $db_password           = $::powerdns::params::db_password,
-  Optional[String[1]]        $db_name               = $::powerdns::params::db_name,
-  Optional[String[1]]        $db_host               = $::powerdns::params::db_host,
-  Boolean                    $custom_repo           = $::powerdns::params::custom_repo,
-  Enum['4.0','4.1']          $version               = $::powerdns::params::version,
-  String[1]                  $mysql_schema_file     = $::powerdns::params::mysql_schema_file,
-  String[1]                  $pgsql_schema_file     = $::powerdns::params::pgsql_schema_file,
+  Boolean                    $authoritative            = $::powerdns::params::authoritative,
+  Boolean                    $recursor                 = $::powerdns::params::recursor,
+  Enum['ldap', 'mysql', 'bind', 'postgresql'] $backend = $::powerdns::params::backend,
+  Boolean                    $backend_install          = $::powerdns::params::backend_install,
+  Boolean                    $backend_create_tables    = $::powerdns::params::backend_create_tables,
+  Optional[String[1]]        $db_root_password         = $::powerdns::params::db_root_password,
+  Optional[String[1]]        $db_username              = $::powerdns::params::db_username,
+  Optional[String[1]]        $db_password              = $::powerdns::params::db_password,
+  Optional[String[1]]        $db_name                  = $::powerdns::params::db_name,
+  Optional[String[1]]        $db_host                  = $::powerdns::params::db_host,
+  Boolean                    $custom_repo              = $::powerdns::params::custom_repo,
+  Enum['4.0','4.1']          $version                  = $::powerdns::params::version,
+  String[1]                  $mysql_schema_file        = $::powerdns::params::mysql_schema_file,
+  String[1]                  $pgsql_schema_file        = $::powerdns::params::pgsql_schema_file,
 ) inherits powerdns::params {
 
   # Do some additional checks. In certain cases, some parameters are no longer optional.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,6 +10,11 @@ class powerdns (
   Optional[String[1]]        $db_password              = $::powerdns::params::db_password,
   Optional[String[1]]        $db_name                  = $::powerdns::params::db_name,
   Optional[String[1]]        $db_host                  = $::powerdns::params::db_host,
+  Optional[String[1]]        $ldap_host                = $::powerdns::params::ldap_host,
+  Optional[String[1]]        $ldap_basedn              = $::powerdns::params::ldap_basedn,
+  Optional[String[1]]        $ldap_method              = $::powerdns::params::ldap_method,
+  Optional[String[1]]        $ldap_binddn              = $::powerdns::params::ldap_binddn,
+  Optional[String[1]]        $ldap_secret              = $::powerdns::params::ldap_secret,
   Boolean                    $custom_repo              = $::powerdns::params::custom_repo,
   Enum['4.0','4.1']          $version                  = $::powerdns::params::version,
   String[1]                  $mysql_schema_file        = $::powerdns::params::mysql_schema_file,
@@ -18,7 +23,7 @@ class powerdns (
 
   # Do some additional checks. In certain cases, some parameters are no longer optional.
   if $authoritative {
-    if ($::powerdns::backend != 'bind') {
+    if ($::powerdns::backend != 'bind') and ($::powerdns::backend != 'ldap') {
       assert_type(String[1], $db_password) |$expected, $actual| {
         fail("'db_password' must be a non-empty string when 'authoritative' == true")
       }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,7 +10,11 @@ class powerdns::params {
   $db_password = undef
   $db_name = 'powerdns'
   $db_host = 'localhost'
+  $ldap_host = 'ldap://localhost/'
+  $ldap_basedn = undef
   $ldap_method = 'strict'
+  $ldap_binddn = undef
+  $ldap_secret = undef
   $custom_repo = false
   $default_package_ensure = installed
   $version = '4.1'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,6 +10,7 @@ class powerdns::params {
   $db_password = undef
   $db_name = 'powerdns'
   $db_host = 'localhost'
+  $ldap_method = 'strict'
   $custom_repo = false
   $default_package_ensure = installed
   $version = '4.1'
@@ -19,6 +20,7 @@ class powerdns::params {
       $authoritative_package = 'pdns'
       $authoritative_service = 'pdns'
       $authoritative_config = '/etc/pdns/pdns.conf'
+      $ldap_backend_package_name = 'pdns-backend-ldap'
       $pgsql_backend_package_name = 'pdns-backend-postgresql'
       $mysql_schema_file = '/usr/share/doc/pdns-backend-mysql-4.?.?/schema.mysql.sql'
       $pgsql_schema_file = '/usr/share/doc/pdns-backend-postgresql-4.?.?/schema.pgsql.sql'
@@ -31,6 +33,7 @@ class powerdns::params {
       $authoritative_package = 'pdns-server'
       $authoritative_service = 'pdns'
       $authoritative_config = '/etc/powerdns/pdns.conf'
+      $ldap_backend_package_name = 'pdns-backend-ldap'
       $pgsql_backend_package_name = 'pdns-backend-pgsql'
       $mysql_schema_file = '/usr/share/doc/pdns-backend-mysql/schema.mysql.sql'
       $pgsql_schema_file = '/usr/share/doc/pdns-backend-pgsql/schema.pgsql.sql'

--- a/spec/classes/powerdns_init_spec.rb
+++ b/spec/classes/powerdns_init_spec.rb
@@ -202,9 +202,9 @@ describe 'powerdns', type: :class do
           context 'with backend_install and backend_create_tables set to false' do
             let(:params) do
               {
-                db_root_password: 'foobar',
-                db_username: 'foo',
-                db_password: 'bar',
+                ldap_basedn: 'ou=foo',
+                ldap_binddn: 'foo',
+                ldap_secret: 'bar',
                 backend: 'ldap',
                 backend_install: false,
                 backend_create_tables: false
@@ -215,8 +215,8 @@ describe 'powerdns', type: :class do
             it { is_expected.to contain_package('pdns-backend-ldap').with('ensure' => 'installed') }
 
             it { is_expected.to contain_powerdns__config('launch').with('value' => 'ldap') }
-            it { is_expected.to contain_powerdns__config('ldap-host').with('value' => 'localhost') }
-            it { is_expected.to contain_powerdns__config('ldap-basedn').with('value' => 'powerdns') }
+            it { is_expected.to contain_powerdns__config('ldap-host').with('value' => 'ldap://localhost/') }
+            it { is_expected.to contain_powerdns__config('ldap-basedn').with('value' => 'ou=foo') }
             it { is_expected.to contain_powerdns__config('ldap-secret').with('value' => 'bar') }
             it { is_expected.to contain_powerdns__config('ldap-binddn').with('value' => 'foo') }
             it { is_expected.to contain_powerdns__config('ldap-method').with('value' => 'strict') }
@@ -231,9 +231,9 @@ describe 'powerdns', type: :class do
           context 'with backend_install set to true' do
             let(:params) do
               {
-                db_root_password: 'foobar',
-                db_username: 'foo',
-                db_password: 'bar',
+                ldap_basedn: 'ou=foo',
+                ldap_binddn: 'foo',
+                ldap_secret: 'bar',
                 backend: 'ldap',
                 backend_install: true,
                 backend_create_tables: false
@@ -247,9 +247,9 @@ describe 'powerdns', type: :class do
           context 'with backend_create_tables set to true' do
             let(:params) do
               {
-                db_root_password: 'foobar',
-                db_username: 'foo',
-                db_password: 'bar',
+                ldap_basedn: 'ou=foo',
+                ldap_binddn: 'foo',
+                ldap_secret: 'bar',
                 backend: 'ldap',
                 backend_install: false,
                 backend_create_tables: true


### PR DESCRIPTION
For another project I use OpenLDAP as backend with PowerDNS and as such quickly added some basic LDAP backend support to this module. It does not depend on any OpenLDAP puppet module from the forge as unfortunately there are none which are really actual and/or working properly. So it's up to the ops to install and configure OpenLDAP and not this module unlike for the MySQL and PostgreSQL backend.

Unit tests all pass and I tested UAT for debian9, centos7 and ubuntu1604 which also pass.

Btw thanks for release 1.3.0 of this module yesterday :+1: I was looking forward that one...