### PR TITLE
Remove bind backend pkg and pgsql config when using Debian repo

### DIFF
--- a/manifests/backends/postgresql.pp
+++ b/manifests/backends/postgresql.pp
@@ -1,5 +1,20 @@
 # postgresql backend for powerdns
 class powerdns::backends::postgresql inherits powerdns {
+  if $facts['os']['family'] == 'Debian' {
+    # Remove the debconf gpgsql configuration file auto-generated when using the package
+    # from Debian repository as it interferes with this module's backend configuration.
+    file { "${::powerdns::params::authoritative_configdir}/pdns.d/pdns.local.gpgsql.conf":
+      ensure  => absent,
+      require => Package[$::powerdns::params::pgsql_backend_package_name],
+    }
+
+    # The pdns-server package from the Debian APT repo automatically installs the bind
+    # backend package which we do not want when using another backend such as pgsql.
+    package { 'pdns-backend-bind':
+      ensure  => purged,
+      require => Package[$::powerdns::params::authoritative_package],
+    }
+  }
 
   # set the configuration variables
   powerdns::config { 'launch':

--- a/spec/classes/powerdns_init_spec.rb
+++ b/spec/classes/powerdns_init_spec.rb
@@ -151,6 +151,12 @@ describe 'powerdns', type: :class do
           end
 
           it { is_expected.to contain_class('powerdns::backends::postgresql') }
+
+          if facts[:operatingsystem] == 'Debian'
+            it { is_expected.to contain_file('/etc/powerdns/pdns.d/pdns.local.gpgsql.conf').with('ensure' => 'absent') }
+            it { is_expected.to contain_package('pdns-backend-bind').with('ensure' => 'purged') }
+          end
+
           it { is_expected.to contain_package(pgsql_backend_package_name).with('ensure' => 'installed') }
           it { is_expected.to contain_postgresql__server__db('powerdns').with('user' => 'foo') }
           it { is_expected.to contain_postgresql_psql('Load SQL schema').with('command' => format('\\i %<file>s', file: pgsql_schema_file)) }


### PR DESCRIPTION
I found out that when using the pdns-server and pdns-backend-pgsql packages from the official Debian APT repository instead of the default PowerDNS APT repo by setting `custom_repo = true` param there are two issues:

* The pdns-server package from Debian automatically install the pdns-backend-bind package.
* The pdns-backend-pgsql package from Debian automatically configures some default configuration using debconf for this backend in the `/etc/powerdns/pdns.d/pdns.local.gpgsql.conf` file.

This PR ensures that the `/etc/powerdns/pdns.d/pdns.local.gpgsql.conf` file gets deleted and that the package pdns-backend-bind gets purged along with its default config file when using Debian. This allows the PowerDNS PostgreSQL backend pacakge to be used from the Debian APT repo directly instead of the default PowerDNS APT repo.

UT all pass and I tested UAT for debian9, centos7 and ubuntu1604 which also pass.