### PR TITLE
Remove bind backend package when using Debian repo with ldap backend

### DIFF
--- a/manifests/backends/ldap.pp
+++ b/manifests/backends/ldap.pp
@@ -1,5 +1,13 @@
 # ldap backend for powerdns
 class powerdns::backends::ldap inherits powerdns {
+  if $facts['os']['family'] == 'Debian' {
+    # The pdns-server package from the Debian APT repo automatically installs the bind
+    # backend package which we do not want when using another backend such as ldap.
+    package { 'pdns-backend-bind':
+      ensure  => purged,
+      require => Package[$::powerdns::params::authoritative_package],
+    }
+  }
 
   # set the configuration variables
   powerdns::config { 'launch':

--- a/spec/classes/powerdns_init_spec.rb
+++ b/spec/classes/powerdns_init_spec.rb
@@ -220,6 +220,10 @@ describe 'powerdns', type: :class do
             it { is_expected.to contain_class('powerdns::backends::ldap') }
             it { is_expected.to contain_package('pdns-backend-ldap').with('ensure' => 'installed') }
 
+            if facts[:operatingsystem] == 'Debian'
+              it { is_expected.to contain_package('pdns-backend-bind').with('ensure' => 'purged') }
+            end
+
             it { is_expected.to contain_powerdns__config('launch').with('value' => 'ldap') }
             it { is_expected.to contain_powerdns__config('ldap-host').with('value' => 'ldap://localhost/') }
             it { is_expected.to contain_powerdns__config('ldap-basedn').with('value' => 'ou=foo') }


### PR DESCRIPTION
Analog to my PR #59 on Debian when using the PowerDNS LDAP backend the BIND backend automatically gets installed although it is not required. This new PR (including unit test) makes sure the PowerDNS BIND backend package gets purged when using the LDAP backend on Debian.

UT all pass and UAT has been tested with debian9, ubuntu1604 and centos7. 