### PR TITLE
custom repo fix: changed unless to if

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,7 +38,7 @@ class powerdns (
   }
 
   # Include the required classes
-  unless $custom_repo {
+  if $custom_repo {
     contain powerdns::repo
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,7 +16,7 @@ class powerdns::params {
   $ldap_method = 'strict'
   $ldap_binddn = undef
   $ldap_secret = undef
-  $custom_repo = false
+  $custom_repo = true
   $custom_epel = false
   $default_package_ensure = installed
   $version = '4.1'


### PR DESCRIPTION
i set the hiera value for `powerdns::custom_repo` to `true` and wondered why the custom repo is not used on my debian stretch machine. after noticeing that `unless` is used i was unsure if i understand it right. to be sure i googled a little bit and found https://stackoverflow.com/a/13245046 

> Executes code if conditional is false.

i am not sure what your intention is but as far as i understand, it should work like "use the custom repo if the value is true"

switching to "if" made it work as expected for me.

do i get something wrong i do i found a bug?

i also changed the default value to "true" to not change the current behavior.