### PR TITLE
also support version 4.2 of powerdns and set as default

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,7 +19,7 @@ class powerdns (
   Optional[String[1]]        $ldap_secret                        = $::powerdns::params::ldap_secret,
   Boolean                    $custom_repo                        = $::powerdns::params::custom_repo,
   Boolean                    $custom_epel                        = $::powerdns::params::custom_epel,
-  Enum['4.0','4.1']          $version                            = $::powerdns::params::version,
+  Enum['4.0','4.1','4.2']    $version                            = $::powerdns::params::version,
   String[1]                  $mysql_schema_file                  = $::powerdns::params::mysql_schema_file,
   String[1]                  $pgsql_schema_file                  = $::powerdns::params::pgsql_schema_file,
 ) inherits powerdns::params {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,7 +20,7 @@ class powerdns::params {
   $custom_repo = false
   $custom_epel = false
   $default_package_ensure = installed
-  $version = '4.1'
+  $version = '4.2'
 
   case $facts['os']['family'] {
     'RedHat': {

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -10,6 +10,9 @@ class powerdns::repo inherits powerdns {
     '4.1': {
       $short_version = '41'
     }
+    '4.2': {
+      $short_version = '42'
+    }
     default: {
       fail("Version ${::powerdns::version} is not supported.")
     }

--- a/spec/classes/powerdns_init_spec.rb
+++ b/spec/classes/powerdns_init_spec.rb
@@ -62,18 +62,18 @@ describe 'powerdns', type: :class do
           when 'RedHat'
             it { is_expected.to contain_package('yum-plugin-priorities') }
             it { is_expected.to contain_yumrepo('powerdns') }
-            it { is_expected.to contain_yumrepo('powerdns').with('baseurl' => 'http://repo.powerdns.com/centos/$basearch/$releasever/auth-41') }
+            it { is_expected.to contain_yumrepo('powerdns').with('baseurl' => 'http://repo.powerdns.com/centos/$basearch/$releasever/auth-42') }
             it { is_expected.to contain_yumrepo('powerdns-recursor') }
-            it { is_expected.to contain_yumrepo('powerdns-recursor').with('baseurl' => 'http://repo.powerdns.com/centos/$basearch/$releasever/rec-41') }
+            it { is_expected.to contain_yumrepo('powerdns-recursor').with('baseurl' => 'http://repo.powerdns.com/centos/$basearch/$releasever/rec-42') }
           end
           case facts[:osfamily]
           when 'Debian'
             it { is_expected.to contain_apt__key('powerdns') }
             it { is_expected.to contain_apt__pin('powerdns') }
             it { is_expected.to contain_apt__source('powerdns') }
-            it { is_expected.to contain_apt__source('powerdns').with_release(/auth-41/) }
+            it { is_expected.to contain_apt__source('powerdns').with_release(/auth-42/) }
             it { is_expected.to contain_apt__source('powerdns-recursor') }
-            it { is_expected.to contain_apt__source('powerdns-recursor').with_release(/rec-41/) }
+            it { is_expected.to contain_apt__source('powerdns-recursor').with_release(/rec-42/) }
 
             # On Ubuntu 17.04 and higher and Debian 9 and higher it expects dirmngr
             it { is_expected.to contain_package('dirmngr') } if facts[:operatingsystem] == 'Ubuntu' && facts[:operatingsystemmajrelease].to_i >= 17


### PR DESCRIPTION
Is there a reason for not supporting powerdns 4.2 yet?

I've tested on centos 7 , and it seems to simply work without any further changes.
Debian-Repositories also exist, with used naming-scheme for version 4.2