### PR TITLE
add support for PDNS 4.3 and refactor data type and support case

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,7 +19,7 @@ class powerdns (
   Optional[String[1]]        $ldap_secret                        = $::powerdns::params::ldap_secret,
   Boolean                    $custom_repo                        = $::powerdns::params::custom_repo,
   Boolean                    $custom_epel                        = $::powerdns::params::custom_epel,
-  Enum['4.0','4.1','4.2']    $version                            = $::powerdns::params::version,
+  Pattern[/4\.(0|1|2|3)/]    $version                            = $::powerdns::params::version,
   String[1]                  $mysql_schema_file                  = $::powerdns::params::mysql_schema_file,
   String[1]                  $pgsql_schema_file                  = $::powerdns::params::pgsql_schema_file,
 ) inherits powerdns::params {

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -3,20 +3,7 @@ class powerdns::repo inherits powerdns {
 
   # The repositories of PowerDNS use a version such as '40' for version 4.0
   # and 41 for version 4.1.
-  case $::powerdns::version {
-    '4.0': {
-      $short_version = '40'
-    }
-    '4.1': {
-      $short_version = '41'
-    }
-    '4.2': {
-      $short_version = '42'
-    }
-    default: {
-      fail("Version ${::powerdns::version} is not supported.")
-    }
-  }
+  $short_version = regsubst($::powerdns::version, /^(\d)\.(\d)$/, '\\1\\2', 'G')
 
   case $facts['os']['family'] {
     'RedHat': {


### PR DESCRIPTION
Using a pattern for version checking is shorter than listing every
version. A case with a default fail is not needed. A regsubst is more
efficient and supported versions are already checked in init.pp