### PR TITLE
Bump apt dependency to 7.6.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -23,7 +23,7 @@
         { "name": "puppetlabs/stdlib", "version_requirement": ">=4.3.2 < 6.0.0" },
         { "name": "puppetlabs/mysql", "version_requirement": ">=3.4.0 < 9.0.0" },
         { "name": "puppetlabs/postgresql", "version_requirement": ">=4.0.0 < 6.0.0" },
-        { "name": "puppetlabs/apt", "version_requirement": ">=2.0.0 < 7.0.0" },
+        { "name": "puppetlabs/apt", "version_requirement": ">=2.0.0 < 7.6.0" },
         { "name": "stahnma/epel", "version_requirement": ">=1.0.0 < 3.0.0" }
     ]
 }


### PR DESCRIPTION
This PR bumps the apt puppet forge module dependency from 7.0.0 to 7.6.0 as requested in issue #77.