### PR TITLE
Improve version pattern matching

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,7 +19,7 @@ class powerdns (
   Optional[String[1]]        $ldap_secret                        = $::powerdns::params::ldap_secret,
   Boolean                    $custom_repo                        = $::powerdns::params::custom_repo,
   Boolean                    $custom_epel                        = $::powerdns::params::custom_epel,
-  Pattern[/4\.(0|1|2|3)/]    $version                            = $::powerdns::params::version,
+  Pattern[/4\.[0-9]+/]       $version                            = $::powerdns::params::version,
   String[1]                  $mysql_schema_file                  = $::powerdns::params::mysql_schema_file,
   String[1]                  $pgsql_schema_file                  = $::powerdns::params::pgsql_schema_file,
 ) inherits powerdns::params {


### PR DESCRIPTION
Don't match for explicit version numbers, but rather any version starting from 4.X, fixes #89 