### PR TITLE
allow local-ipv6 to be empty, fixes #76

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,7 +10,8 @@ define powerdns::config(
     'gmysql-dnssec',
     'only-notify',
     'allow-notify-from',
-    'security-poll-suffix'
+    'security-poll-suffix',
+    'local-ipv6'
   ]
   unless $ensure == 'absent' or ($setting in $empty_value_allowed) {
     assert_type(Variant[String[1], Integer], $value) |$_expected, $_actual| {


### PR DESCRIPTION
This fixes #76 
This module is capable of managing powerdns 4.1/4.2 e.g. on Ubuntu Bionic or Focal