### PR TITLE
Use package_ensure on backends' packages

### DIFF
--- a/manifests/backends/ldap.pp
+++ b/manifests/backends/ldap.pp
@@ -1,5 +1,5 @@
 # ldap backend for powerdns
-class powerdns::backends::ldap inherits powerdns {
+class powerdns::backends::ldap ($package_ensure = $powerdns::params::default_package_ensure) inherits powerdns {
   if $facts['os']['family'] == 'Debian' {
     # The pdns-server package from the Debian APT repo automatically installs the bind
     # backend package which we do not want when using another backend such as ldap.
@@ -55,7 +55,7 @@ class powerdns::backends::ldap inherits powerdns {
   if $::powerdns::params::ldap_backend_package_name {
     # set up the powerdns backend
     package { $::powerdns::params::ldap_backend_package_name:
-      ensure  => installed,
+      ensure  => $package_ensure,
       before  => Service[$::powerdns::params::authoritative_service],
       require => Package[$::powerdns::params::authoritative_package],
     }

--- a/manifests/backends/mysql.pp
+++ b/manifests/backends/mysql.pp
@@ -1,5 +1,5 @@
 # mysql backend for powerdns
-class powerdns::backends::mysql inherits powerdns {
+class powerdns::backends::mysql ($package_ensure = $powerdns::params::default_package_ensure) inherits powerdns {
   # set the configuration variables
   powerdns::config { 'launch':
     ensure  => present,
@@ -46,7 +46,7 @@ class powerdns::backends::mysql inherits powerdns {
   if $::powerdns::params::mysql_backend_package_name {
     # set up the powerdns backend
     package { $::powerdns::params::mysql_backend_package_name:
-      ensure  => installed,
+      ensure  => $package_ensure,
       before  => Service[$::powerdns::params::authoritative_service],
       require => Package[$::powerdns::params::authoritative_package],
     }

--- a/manifests/backends/postgresql.pp
+++ b/manifests/backends/postgresql.pp
@@ -1,5 +1,5 @@
 # postgresql backend for powerdns
-class powerdns::backends::postgresql inherits powerdns {
+class powerdns::backends::postgresql ($package_ensure = $powerdns::params::default_package_ensure) inherits powerdns {
   if $facts['os']['family'] == 'Debian' {
     # Remove the debconf gpgsql configuration file auto-generated when using the package
     # from Debian repository as it interferes with this module's backend configuration.
@@ -55,7 +55,7 @@ class powerdns::backends::postgresql inherits powerdns {
   # set up the powerdns backend
   if $::powerdns::params::pgsql_backend_package_name {
     package { $::powerdns::params::pgsql_backend_package_name:
-      ensure  => installed,
+      ensure  => $package_ensure,
       before  => Service[$::powerdns::params::authoritative_service],
       require => Package[$::powerdns::params::authoritative_package],
     }

--- a/manifests/backends/sqlite.pp
+++ b/manifests/backends/sqlite.pp
@@ -1,5 +1,5 @@
 # sqlite backend for powerdns
-class powerdns::backends::sqlite inherits powerdns {
+class powerdns::backends::sqlite ($package_ensure = $powerdns::params::default_package_ensure) inherits powerdns {
   # set the configuration variables
   powerdns::config { 'launch':
     ensure  => present,
@@ -18,7 +18,7 @@ class powerdns::backends::sqlite inherits powerdns {
   # set up the powerdns backend
   if $::powerdns::params::sqlite_backend_package_name {
     package { $::powerdns::params::sqlite_backend_package_name:
-      ensure  => installed,
+      ensure  => $package_ensure,
       before  => Service[$::powerdns::params::authoritative_service],
       require => Package[$::powerdns::params::authoritative_package],
     }
@@ -26,7 +26,7 @@ class powerdns::backends::sqlite inherits powerdns {
   if $::powerdns::backend_install {
     if ! defined(Package[$::powerdns::sqlite_package_name]) {
       package { $::powerdns::sqlite_package_name:
-        ensure => installed,
+        ensure => $package_ensure,
       }
     }
   }


### PR DESCRIPTION
When upgrading PDNS the backend package is not upgraded to the correct version, resulting in PDNS not starting.

This commit aim to fix this behaviour. By default, the packages_ensure remains `installed` as of now, but it can be tweeked to reflect changes to the pdns package.