### PR TITLE
Use the Rocky Linux mirrorlist when the OS name is Rocky

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -19,12 +19,20 @@ class powerdns::repo inherits powerdns {
       }
 
       if versioncmp($::operatingsystemmajrelease, '8') >= 0 {
+        if ($facts['os']['name'] == 'Rocky') {
+          $mirrorlist = "https://mirrors.rockylinux.org/mirrorlist?arch=\$basearch&repo=PowerTools-\$releasever"
+          $gpgkey = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rockyofficial'
+        } else {
+          $mirrorlist = "http://mirrorlist.centos.org/?release=\$releasever&arch=\$basearch&repo=PowerTools&infra=\$infra"
+          $gpgkey = 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial'
+        }
+
         yumrepo { 'powertools':
           ensure     => 'present',
           descr      => 'PowerTools',
-          mirrorlist => "http://mirrorlist.centos.org/?release=\$releasever&arch=\$basearch&repo=PowerTools&infra=\$infra",
+          mirrorlist => $mirrorlist,
           enabled    => 'true',
-          gpgkey     => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial',
+          gpgkey     => $gpgkey,
           gpgcheck   => 'true',
         }
       }

--- a/spec/classes/powerdns_init_spec.rb
+++ b/spec/classes/powerdns_init_spec.rb
@@ -60,6 +60,9 @@ describe 'powerdns', type: :class do
           case facts[:osfamily]
           when 'RedHat'
             it { is_expected.to contain_package('yum-plugin-priorities') } if facts[:operatingsystemmajrelease].to_i < 8
+            it { is_expected.to contain_yumrepo('powertools') } if facts[:operatingsystemmajrelease].to_i >= 8
+            it { is_expected.to contain_yumrepo('powertools').with('mirrorlist' => 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=PowerTools&infra=$infra') } if facts[:operatingsystem] != 'Rocky' && facts[:operatingsystemmajrelease].to_i >= 8
+            it { is_expected.to contain_yumrepo('powertools').with('mirrorlist' => 'https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=PowerTools-$releasever') } if facts[:operatingsystem] == 'Rocky' && facts[:operatingsystemmajrelease].to_i >= 8
             it { is_expected.to contain_yumrepo('powerdns') }
             it { is_expected.to contain_yumrepo('powerdns').with('baseurl' => 'http://repo.powerdns.com/centos/$basearch/$releasever/auth-42') }
             it { is_expected.to contain_yumrepo('powerdns-recursor') }


### PR DESCRIPTION
If the OS name is Rocky the Rocky linux mirrors.rockylinux.org should be used.