### PR TITLE
allow to manage zones and records (with opt out) with puppet 

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,17 +123,19 @@ The zone records can be managed through the powerdns\_record resource. As an exa
 ``` puppet
  powerdns_record{'nameserver1':
    target_zone => 'example.org',
-   rname       => 'example.org',
+   rname       => '.',  # a dot takes the target_zone only as rname
    rtype       => 'NS',
    rttl        => '4242',
-   rcontent    => 'ns1.example.org'
+   rcontent    => 'ns1.example.org.' # pay attention to the dot at the end !
  }
  powerdns_record{'ns1.example.org':
    rcontent => '127.0.0.1',
  }
- powerdns_record{'ns1.example.org':
-   rtype    => 'AAAA',
-   rcontent => '::1',
+ powerdns_record{'ipv6-ns1.example.org':
+   target_zone => 'example.org',
+   rname       => 'ns1',  # for the full record, the target_zone will be amended
+   rtype       => 'AAAA',
+   rcontent    => '::1',
  }
  powerdns_record{'www-server':
    target_zone => 'example.org',

--- a/README.md
+++ b/README.md
@@ -100,6 +100,49 @@ class { 'powerdns':
 }
 ```
 
+### Manage zones with this module
+With this module you can manage zones if you use a backend that is capable of doing so (eg. sqllite, postgres or mysql).
+
+You can add a zone 'example.org' by using:
+``` puppet
+ powerdns_zone{'example.org': }
+```
+This will add the zone which is then managed through puppet any records not added 
+through puppet will be deleted additionaly a SOA record is generated. To just ensure the
+zone is available, but not manage any records use (and do not add any powerdns\_record
+resources with target this domain): 
+``` puppet
+ powerdns_zone{'example.org':
+   manage_records => false,
+ }
+```
+
+To addjust the SOA record (if add\_soa is set to true), use the soa\_\* parameters documented in the powerdns\_record resource.
+
+The zone records can be managed through the powerdns\_record resource. As an example we add a NS an A and an AAAA record:
+``` puppet
+ powerdns_record{'nameserver1':
+   target_zone => 'example.org',
+   rname       => 'example.org',
+   rtype       => 'NS',
+   rttl        => '4242',
+   rcontent    => 'ns1.example.org'
+ }
+ powerdns_record{'ns1.example.org':
+   rcontent => '127.0.0.1',
+ }
+ powerdns_record{'ns1.example.org':
+   rtype    => 'AAAA',
+   rcontent => '::1',
+ }
+ powerdns_record{'www-server':
+   target_zone => 'example.org',
+   rname       => 'www',
+   rcontent    => '127.0.0.1'
+ }
+```
+Remark: if the target\_zone is not managed with powerdns\_zone resource, powerdns\_record does not change anything !
+
 ## Reference
 
 ### Parameters

--- a/lib/puppet/provider/powerdns_zone_private/pdnsutil.rb
+++ b/lib/puppet/provider/powerdns_zone_private/pdnsutil.rb
@@ -1,0 +1,84 @@
+
+# This file contains a provider for the resource type `powerdns_zone`,
+#
+require 'tempfile'
+Puppet::Type.type(:powerdns_zone_private).provide(
+  :pdnsutil,
+) do
+  desc "A provider for the resource type `powerdns_zone`,
+        which manages a zone on powerdns
+        using the pdnsutil command."
+
+  commands pdnsutil: 'pdnsutil'
+
+  def get_options
+    options = []
+    if resource[:config_name].to_s != ''
+      options.insert(0, '--config-name')
+      options.insert(1, resource[:config_name])
+    end
+    if resource[:config_dir].to_s != ''
+      options.insert(0, '--config-dir')
+      options.insert(1, resource[:config_dir])
+    end
+    options
+  end
+
+  def create
+    pdnsutil get_options, 'create-zone', resource[:name]
+    set_records('1') if resource[:manage_records]
+  end
+
+  def destroy
+    pdnsutil get_options, 'delete-zone', resource[:name]
+  end
+
+  def content=(_content)
+    return unless resource[:manage_records]
+    set_records(@serial)
+    pdnsutil get_options, 'increase-serial', resource[:name]
+  end
+
+  def set_records(serial)
+    tmpfile = Tempfile.new(resource[:name])
+    tmpfile.write(resource[:content].gsub(%r{_SERIAL_}, serial))
+    tmpfile.rewind
+    pdnsutil(get_options, 'load-zone', resource[:name], tmpfile.path)
+  ensure
+    tmpfile.close
+    tmpfile.unlink
+  end
+
+  def find_soa(records)
+    records.each_with_index do |r, idx|
+      return idx if r.match?(%r{\tSOA\t})
+    end
+    'notfound'
+  end
+
+  def content
+    return '' unless resource[:manage_records]
+    c = pdnsutil(get_options, 'list-zone', resource[:name])
+    records = c.split("\n")
+    soanr = find_soa(records)
+    if soanr == 'notfound'
+      @serial = '1'
+      return c
+    end
+    soarec = records[soanr].split(' ')
+    @serial = soarec[-5]
+    soarec[-5] = '_SERIAL_'
+    records[soanr] = soarec[0..3].join("\t") + "\t" + soarec[4..10].join(' ')
+
+    records.join("\n") + "\n"
+  end
+
+  def exists?
+    pdnsutil(get_options, 'list-all-zones').split("\n").each do |line|
+      if line == resource[:name]
+        return true
+      end
+    end
+    false
+  end
+end

--- a/lib/puppet/type/powerdns_record.rb
+++ b/lib/puppet/type/powerdns_record.rb
@@ -5,9 +5,7 @@ Puppet::Type.newtype(:powerdns_record) do
     desc 'name of the record as namevar'
 
     validate do |value|
-      unless value.is_a?(String)
-        raise ArgumentError, 'The name of the zone needs to be a string'
-      end
+      raise ArgumentError, 'The name of the zone needs to be a string' unless value.is_a?(String)
     end
   end
 
@@ -16,9 +14,7 @@ Puppet::Type.newtype(:powerdns_record) do
     defaultto { @resource[:name].split('.').drop(1).join('.') }
 
     validate do |value|
-      unless value.is_a?(String)
-        raise ArgumentError, 'target_zone needs to be a string'
-      end
+      raise ArgumentError, 'target_zone needs to be a string' unless value.is_a?(String)
     end
   end
 
@@ -28,9 +24,7 @@ Puppet::Type.newtype(:powerdns_record) do
          '
     defaultto { @resource[:name].split('.')[0] }
     validate do |value|
-      unless value.is_a?(String)
-        raise ArgumentError, 'target_zone needs to be a string'
-      end
+      raise ArgumentError, 'target_zone needs to be a string' unless value.is_a?(String)
     end
   end
 
@@ -38,9 +32,7 @@ Puppet::Type.newtype(:powerdns_record) do
     desc "the class of record (defaults to 'IN')"
     defaultto 'IN'
     validate do |value|
-      unless value.is_a?(String)
-        raise ArgumentError, 'target_zone needs to be a string'
-      end
+      raise ArgumentError, 'target_zone needs to be a string' unless value.is_a?(String)
     end
   end
 
@@ -48,9 +40,7 @@ Puppet::Type.newtype(:powerdns_record) do
     desc 'the record type'
     defaultto 'A'
     validate do |value|
-      unless value.is_a?(String)
-        raise ArgumentError, 'target_zone needs to be a string'
-      end
+      raise ArgumentError, 'target_zone needs to be a string' unless value.is_a?(String)
     end
   end
 
@@ -58,9 +48,7 @@ Puppet::Type.newtype(:powerdns_record) do
     desc 'the ttl of the record'
     defaultto '3600'
     validate do |value|
-      unless value.is_a?(String)
-        raise ArgumentError, 'target_zone needs to be a string'
-      end
+      raise ArgumentError, 'target_zone needs to be a string' unless value.is_a?(String)
     end
   end
 

--- a/lib/puppet/type/powerdns_record.rb
+++ b/lib/puppet/type/powerdns_record.rb
@@ -1,0 +1,70 @@
+Puppet::Type.newtype(:powerdns_record) do
+  @doc = ' ensure a zone exists.'
+
+  newparam(:name, namevar: true) do
+    desc 'name of the record as namevar'
+
+    validate do |value|
+      unless value.is_a?(String)
+        raise ArgumentError, 'The name of the zone needs to be a string'
+      end
+    end
+  end
+
+  newparam(:target_zone) do
+    desc 'the target zone defaults to all characters after the first . in the title.'
+    defaultto { @resource[:name].split('.').drop(1).join('.') }
+
+    validate do |value|
+      unless value.is_a?(String)
+        raise ArgumentError, 'target_zone needs to be a string'
+      end
+    end
+  end
+
+  newparam(:rname) do
+    desc 'the name of the record to add (remark target zone will be added)
+          defaults to the first characters of the title until the first .)
+         '
+    defaultto { @resource[:name].split('.')[0] }
+    validate do |value|
+      unless value.is_a?(String)
+        raise ArgumentError, 'target_zone needs to be a string'
+      end
+    end
+  end
+
+  newparam(:rclass) do
+    desc "the class of record (defaults to 'IN')"
+    defaultto 'IN'
+    validate do |value|
+      unless value.is_a?(String)
+        raise ArgumentError, 'target_zone needs to be a string'
+      end
+    end
+  end
+
+  newparam(:rtype) do
+    desc 'the record type'
+    defaultto 'A'
+    validate do |value|
+      unless value.is_a?(String)
+        raise ArgumentError, 'target_zone needs to be a string'
+      end
+    end
+  end
+
+  newparam(:rttl) do
+    desc 'the ttl of the record'
+    defaultto '3600'
+    validate do |value|
+      unless value.is_a?(String)
+        raise ArgumentError, 'target_zone needs to be a string'
+      end
+    end
+  end
+
+  newparam(:rcontent) do
+    desc 'the content of the record'
+  end
+end

--- a/lib/puppet/type/powerdns_record.rb
+++ b/lib/puppet/type/powerdns_record.rb
@@ -19,9 +19,10 @@ Puppet::Type.newtype(:powerdns_record) do
   end
 
   newparam(:rname) do
-    desc 'the name of the record to add (remark target zone will be added)
-          defaults to the first characters of the title until the first .)
-         '
+    desc "the name of the record to add (remark target zone will be added)
+          defaults to the first characters of the title until the first '.'.
+          to add a record equal the taget_zone, add a '.' only.
+         "
     defaultto { @resource[:name].split('.')[0] }
     validate do |value|
       raise ArgumentError, 'target_zone needs to be a string' unless value.is_a?(String)

--- a/lib/puppet/type/powerdns_zone.rb
+++ b/lib/puppet/type/powerdns_zone.rb
@@ -1,0 +1,205 @@
+Puppet::Type.newtype(:powerdns_zone) do
+  @doc = 'ensure a zone exists. The zone is managed using the
+         resource powerdns_zone_private'
+
+  newparam(:name, namevar: true) do
+    desc 'name of the zone name as namevar'
+
+    validate do |value|
+      unless value.is_a?(String)
+        raise ArgumentError, 'The name of the zone needs to be a string'
+      end
+    end
+  end
+
+  newparam(:zone_ensure) do
+    desc 'ensure parameter for the zone, use present/absent'
+    defaultto 'present'
+  end
+
+  newparam(:config_name) do
+    desc "Virtual configuration name for pdnsutil --config-name parameter, defaults to '' which will ignore the parameter."
+    defaultto ''
+
+    validate do |value|
+      unless value.is_a?(String)
+        raise ArgumentError, 'config_name needs to be a string'
+      end
+    end
+  end
+
+  newparam(:config_dir) do
+    desc "Location directory of pdns.conf file for pdnsutil --config-dir parameter, defaults to '' which will ignore and take the system default."
+    defaultto ''
+    validate do |value|
+      unless value.is_a?(String)
+        raise ArgumentError, 'config_dir needs to be a string'
+      end
+    end
+  end
+
+  newparam(:show_diff, boolean: true, parent: Puppet::Parameter::Boolean) do
+    desc "Whether to display differences when the zone changes, defaulting to
+        false. Since zones can be huge, use this only for debugging"
+    defaultto :false
+  end
+
+  newparam(:manage_records, boolean: true, parent: Puppet::Parameter::Boolean) do
+    desc 'If we manage the all zone records for the domain (any records not managed with puppet will be purged).
+         The default is true, to manage the SOA record and all zone records through puppet for the zone.
+         If set to false, ensurance of zone creation is done only and the administration of zone records can be done through
+         web Interface or any other preferred method.
+         '
+    defaultto :true
+  end
+
+  newparam(:soa_ttl) do
+    desc 'ttl for SOA record'
+    defaultto '3600'
+    validate do |value|
+      unless value.is_a?(String)
+        raise ArgumentError, 'config_dir needs to be a string'
+      end
+    end
+  end
+
+  newparam(:soa_class) do
+    desc 'zone class for SOA record'
+    defaultto 'IN'
+    validate do |value|
+      unless value.is_a?(String)
+        raise ArgumentError, 'config_dir needs to be a string'
+      end
+    end
+  end
+
+  newparam(:soa_mname) do
+    desc 'primary master name server for the zone for SOA record'
+    defaultto 'a.powerdns.server'
+    validate do |value|
+      unless value.is_a?(String)
+        raise ArgumentError, 'config_dir needs to be a string'
+      end
+    end
+  end
+
+  newparam(:soa_rname) do
+    desc 'Email address of the administrator responsible for this zone for SOA record'
+    defaultto 'hostmaster'
+    validate do |value|
+      unless value.is_a?(String)
+        raise ArgumentError, 'config_dir needs to be a string'
+      end
+    end
+  end
+
+  newparam(:soa_refresh) do
+    desc 'Number of seconds after which secondary name servers should query the master for the SOA record, to detect zone changes'
+    defaultto '10800'
+    validate do |value|
+      unless value.is_a?(String)
+        raise ArgumentError, 'config_dir needs to be a string'
+      end
+    end
+  end
+
+  newparam(:soa_retry) do
+    desc 'Number of seconds after which secondary name servers should retry to request the serial number from the master if the master does not respond'
+    defaultto '3600'
+    validate do |value|
+      unless value.is_a?(String)
+        raise ArgumentError, 'config_dir needs to be a string'
+      end
+    end
+  end
+
+  newparam(:soa_expire) do
+    desc 'Number of seconds after which secondary name servers should stop answering request for this zone if the master does not respond.'
+    defaultto '604800'
+    validate do |value|
+      unless value.is_a?(String)
+        raise ArgumentError, 'config_dir needs to be a string'
+      end
+    end
+  end
+
+  newparam(:soa_minttl) do
+    desc 'Minimum ttl in seconds, negativ response caching ttl'
+    defaultto '3600'
+    validate do |value|
+      unless value.is_a?(String)
+        raise ArgumentError, 'config_dir needs to be a string'
+      end
+    end
+  end
+
+  def soa_record
+    # create the soa record
+    soa = [self['soa_mname'], self['soa_rname'], '_SERIAL_', self['soa_refresh'], self['soa_retry'], self['soa_expire'], self['soa_minttl']].join(' ')
+    [self['name'], self['soa_ttl'], self['soa_class'], 'SOA', soa].join("\t")
+  end
+
+  def records
+    # Collect records that target this zone.
+    @records ||= catalog.resources.map { |resource|
+      next unless resource.is_a?(Puppet::Type.type(:powerdns_record))
+
+      if resource[:target_zone] == title
+        resource
+      end
+    }.compact
+  end
+
+  def should_content
+    # collect and sort all records for content
+    content = [].push(soa_record)
+
+    records.each do |r|
+      content.push([r[:rname] + '.' + r[:target_zone], r[:rttl], r[:rclass], r[:rtype], r[:rcontent]].join("\t"))
+    end
+    content.sort.join("\n")
+  end
+
+  def generate
+    # create the powerdns_zone_private resource as a copy of this resource
+    # without content
+    powerdns_zone_private_opts = {}
+
+    [:name,
+     :config_name,
+     :config_dir,
+     :show_diff,
+     :manage_records].each do |p|
+      powerdns_zone_private_opts[p] = self[p] unless self[p].nil?
+    end
+    powerdns_zone_private_opts['ensure'] = self['zone_ensure']
+
+    excluded_metaparams = [:before, :notify, :require, :subscribe, :tag]
+
+    Puppet::Type.metaparams.each do |metaparam|
+      unless self[metaparam].nil? || excluded_metaparams.include?(metaparam)
+        powerdns_zone_private_opts[metaparam] = self[metaparam]
+      end
+    end
+
+    [Puppet::Type.type(:powerdns_zone_private).new(powerdns_zone_private_opts)]
+  end
+
+  def eval_generate
+    # add the content to the powerdns_zone_private resource containing
+    # ower on content and the content of the matching powerdns_record resources
+    content = should_content
+    catalog.resource("Powerdns_zone_private[#{self[:name]}]")[:content] = content
+
+    [catalog.resource("Powerdns_zone_private[#{self[:name]}]")]
+  end
+
+  # autorequire the powerdns class
+  autorequire(:service) do
+    ['pdns']
+  end
+
+  # autorequire the powerdns_records
+  autorequire(:powerdns_record) do
+  end
+end

--- a/lib/puppet/type/powerdns_zone.rb
+++ b/lib/puppet/type/powerdns_zone.rb
@@ -6,9 +6,7 @@ Puppet::Type.newtype(:powerdns_zone) do
     desc 'name of the zone name as namevar'
 
     validate do |value|
-      unless value.is_a?(String)
-        raise ArgumentError, 'The name of the zone needs to be a string'
-      end
+      raise ArgumentError, 'The name of the zone needs to be a string' unless value.is_a?(String)
     end
   end
 
@@ -22,9 +20,7 @@ Puppet::Type.newtype(:powerdns_zone) do
     defaultto ''
 
     validate do |value|
-      unless value.is_a?(String)
-        raise ArgumentError, 'config_name needs to be a string'
-      end
+      raise ArgumentError, 'config_name needs to be a string' unless value.is_a?(String)
     end
   end
 
@@ -32,16 +28,14 @@ Puppet::Type.newtype(:powerdns_zone) do
     desc "Location directory of pdns.conf file for pdnsutil --config-dir parameter, defaults to '' which will ignore and take the system default."
     defaultto ''
     validate do |value|
-      unless value.is_a?(String)
-        raise ArgumentError, 'config_dir needs to be a string'
-      end
+      raise ArgumentError, 'config_dir needs to be a string' unless value.is_a?(String)
     end
   end
 
   newparam(:show_diff, boolean: true, parent: Puppet::Parameter::Boolean) do
     desc "Whether to display differences when the zone changes, defaulting to
         false. Since zones can be huge, use this only for debugging"
-    defaultto :false
+    defaultto :false # rubocop:disable Lint/BooleanSymbol
   end
 
   newparam(:manage_records, boolean: true, parent: Puppet::Parameter::Boolean) do
@@ -50,16 +44,14 @@ Puppet::Type.newtype(:powerdns_zone) do
          If set to false, ensurance of zone creation is done only and the administration of zone records can be done through
          web Interface or any other preferred method.
          '
-    defaultto :true
+    defaultto :true # rubocop:disable Lint/BooleanSymbol
   end
 
   newparam(:soa_ttl) do
     desc 'ttl for SOA record'
     defaultto '3600'
     validate do |value|
-      unless value.is_a?(String)
-        raise ArgumentError, 'config_dir needs to be a string'
-      end
+      raise ArgumentError, 'config_dir needs to be a string' unless value.is_a?(String)
     end
   end
 
@@ -67,9 +59,7 @@ Puppet::Type.newtype(:powerdns_zone) do
     desc 'zone class for SOA record'
     defaultto 'IN'
     validate do |value|
-      unless value.is_a?(String)
-        raise ArgumentError, 'config_dir needs to be a string'
-      end
+      raise ArgumentError, 'config_dir needs to be a string' unless value.is_a?(String)
     end
   end
 
@@ -77,9 +67,7 @@ Puppet::Type.newtype(:powerdns_zone) do
     desc 'primary master name server for the zone for SOA record'
     defaultto 'a.powerdns.server'
     validate do |value|
-      unless value.is_a?(String)
-        raise ArgumentError, 'config_dir needs to be a string'
-      end
+      raise ArgumentError, 'config_dir needs to be a string' unless value.is_a?(String)
     end
   end
 
@@ -87,9 +75,7 @@ Puppet::Type.newtype(:powerdns_zone) do
     desc 'Email address of the administrator responsible for this zone for SOA record'
     defaultto 'hostmaster'
     validate do |value|
-      unless value.is_a?(String)
-        raise ArgumentError, 'config_dir needs to be a string'
-      end
+      raise ArgumentError, 'config_dir needs to be a string' unless value.is_a?(String)
     end
   end
 
@@ -97,9 +83,7 @@ Puppet::Type.newtype(:powerdns_zone) do
     desc 'Number of seconds after which secondary name servers should query the master for the SOA record, to detect zone changes'
     defaultto '10800'
     validate do |value|
-      unless value.is_a?(String)
-        raise ArgumentError, 'config_dir needs to be a string'
-      end
+      raise ArgumentError, 'config_dir needs to be a string' unless value.is_a?(String)
     end
   end
 
@@ -107,9 +91,7 @@ Puppet::Type.newtype(:powerdns_zone) do
     desc 'Number of seconds after which secondary name servers should retry to request the serial number from the master if the master does not respond'
     defaultto '3600'
     validate do |value|
-      unless value.is_a?(String)
-        raise ArgumentError, 'config_dir needs to be a string'
-      end
+      raise ArgumentError, 'config_dir needs to be a string' unless value.is_a?(String)
     end
   end
 
@@ -117,9 +99,7 @@ Puppet::Type.newtype(:powerdns_zone) do
     desc 'Number of seconds after which secondary name servers should stop answering request for this zone if the master does not respond.'
     defaultto '604800'
     validate do |value|
-      unless value.is_a?(String)
-        raise ArgumentError, 'config_dir needs to be a string'
-      end
+      raise ArgumentError, 'config_dir needs to be a string' unless value.is_a?(String)
     end
   end
 
@@ -127,9 +107,7 @@ Puppet::Type.newtype(:powerdns_zone) do
     desc 'Minimum ttl in seconds, negativ response caching ttl'
     defaultto '3600'
     validate do |value|
-      unless value.is_a?(String)
-        raise ArgumentError, 'config_dir needs to be a string'
-      end
+      raise ArgumentError, 'config_dir needs to be a string' unless value.is_a?(String)
     end
   end
 
@@ -141,13 +119,11 @@ Puppet::Type.newtype(:powerdns_zone) do
 
   def records
     # Collect records that target this zone.
-    @records ||= catalog.resources.map { |resource|
+    @records ||= catalog.resources.map do |resource|
       next unless resource.is_a?(Puppet::Type.type(:powerdns_record))
 
-      if resource[:target_zone] == title
-        resource
-      end
-    }.compact
+      resource if resource[:target_zone] == title
+    end.compact
   end
 
   def should_content
@@ -155,11 +131,13 @@ Puppet::Type.newtype(:powerdns_zone) do
     content = [].push(soa_record)
 
     records.each do |r|
-      content.push([r[:rname] + '.' + r[:target_zone], r[:rttl], r[:rclass], r[:rtype], r[:rcontent]].join("\t"))
+      content.push([r[:rname] + '.' + r[:target_zone], r[:rttl], r[:rclass], r[:rtype], r[:rcontent]].join("\t")) # rubocop:disable Style/StringConcatenation
     end
     content.sort.join("\n")
   end
 
+  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/AbcSize
   def generate
     # create the powerdns_zone_private resource as a copy of this resource
     # without content
@@ -177,13 +155,13 @@ Puppet::Type.newtype(:powerdns_zone) do
     excluded_metaparams = [:before, :notify, :require, :subscribe, :tag]
 
     Puppet::Type.metaparams.each do |metaparam|
-      unless self[metaparam].nil? || excluded_metaparams.include?(metaparam)
-        powerdns_zone_private_opts[metaparam] = self[metaparam]
-      end
+      powerdns_zone_private_opts[metaparam] = self[metaparam] unless self[metaparam].nil? || excluded_metaparams.include?(metaparam)
     end
 
     [Puppet::Type.type(:powerdns_zone_private).new(powerdns_zone_private_opts)]
   end
+  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/MethodLength
 
   def eval_generate
     # add the content to the powerdns_zone_private resource containing
@@ -199,7 +177,9 @@ Puppet::Type.newtype(:powerdns_zone) do
     ['pdns']
   end
 
+  # rubocop:disable Lint/EmptyBlock
   # autorequire the powerdns_records
   autorequire(:powerdns_record) do
   end
+  # rubocop:enable Lint/EmptyBlock
 end

--- a/lib/puppet/type/powerdns_zone.rb
+++ b/lib/puppet/type/powerdns_zone.rb
@@ -39,9 +39,9 @@ Puppet::Type.newtype(:powerdns_zone) do
   end
 
   newparam(:manage_records, boolean: true, parent: Puppet::Parameter::Boolean) do
-    desc 'If we manage the all zone records for the domain (any records not managed with puppet will be purged).
+    desc 'If puppet shall manage all zone records for the domain (any records not managed with puppet will be purged).
          The default is true, to manage the SOA record and all zone records through puppet for the zone.
-         If set to false, ensurance of zone creation is done only and the administration of zone records can be done through
+         If set to false, ensurance of zone creation is done only and the administration of zone records needs to be done through
          web Interface or any other preferred method.
          '
     defaultto :true # rubocop:disable Lint/BooleanSymbol
@@ -126,15 +126,23 @@ Puppet::Type.newtype(:powerdns_zone) do
     end.compact
   end
 
+  # rubocop:disable Metrics/AbcSize
   def should_content
     # collect and sort all records for content
     content = [].push(soa_record)
 
     records.each do |r|
-      content.push([r[:rname] + '.' + r[:target_zone], r[:rttl], r[:rclass], r[:rtype], r[:rcontent]].join("\t")) # rubocop:disable Style/StringConcatenation
+      # rubocop:disable Style/StringConcatenation
+      if r[:rname] == '.'
+        content.push([r[:target_zone], r[:rttl], r[:rclass], r[:rtype], r[:rcontent]].join("\t"))
+      else
+        content.push([r[:rname] + '.' + r[:target_zone], r[:rttl], r[:rclass], r[:rtype], r[:rcontent]].join("\t"))
+      end
+      # rubocop:enable Style/StringConcatenation
     end
     content.sort.join("\n")
   end
+  # rubocop:enable Metrics/AbcSize
 
   # rubocop:disable Metrics/MethodLength
   # rubocop:disable Metrics/AbcSize

--- a/lib/puppet/type/powerdns_zone_private.rb
+++ b/lib/puppet/type/powerdns_zone_private.rb
@@ -12,9 +12,7 @@ Puppet::Type.newtype(:powerdns_zone_private) do
     desc 'name of the zone name as namevar'
 
     validate do |value|
-      unless value.is_a?(String)
-        raise ArgumentError, 'The name of the zone needs to be a string'
-      end
+      raise ArgumentError, 'The name of the zone needs to be a string' unless value.is_a?(String)
     end
   end
 
@@ -23,9 +21,7 @@ Puppet::Type.newtype(:powerdns_zone_private) do
     defaultto ''
 
     validate do |value|
-      unless value.is_a?(String)
-        raise ArgumentError, 'config_name needs to be a string'
-      end
+      raise ArgumentError, 'config_name needs to be a string' unless value.is_a?(String)
     end
   end
 
@@ -33,21 +29,19 @@ Puppet::Type.newtype(:powerdns_zone_private) do
     desc 'Location of pdns.conf. Default is which will ignore the property.'
     defaultto ''
     validate do |value|
-      unless value.is_a?(String)
-        raise ArgumentError, 'config_dir needs to be a string'
-      end
+      raise ArgumentError, 'config_dir needs to be a string' unless value.is_a?(String)
     end
   end
 
   newparam(:manage_records, boolean: true, parent: Puppet::Parameter::Boolean) do
     desc 'if we manage the all zone records for the domain (any records not managed with puppet will be purged).'
-    defaultto :true
+    defaultto :true # rubocop:disable Lint/BooleanSymbol
   end
 
   newparam(:show_diff, boolean: true, parent: Puppet::Parameter::Boolean) do
     desc "Whether to display differences when the zone changes, defaulting to
         false. Since zones can be huge, use this only for debugging"
-    defaultto :false
+    defaultto :false # rubocop:disable Lint/BooleanSymbol
   end
 
   newproperty(:content) do
@@ -55,7 +49,7 @@ Puppet::Type.newtype(:powerdns_zone_private) do
 
     munge do |value|
       if @resource[:manage_records]
-        ("$ORIGIN .\n" + value).to_s.gsub(%r{\n+$}, '') + "\n"
+        ("$ORIGIN .\n" + value).to_s.gsub(/\n+$/, '') + "\n" # rubocop:disable Style/StringConcatenation
       else
         ''
       end
@@ -63,17 +57,17 @@ Puppet::Type.newtype(:powerdns_zone_private) do
 
     def should_to_s(value)
       if @resource[:show_diff]
-        ":\n" + value
+        ":\n" + value # rubocop:disable Style/StringConcatenation
       else
-        '{md5}' + Digest::MD5.hexdigest(value.to_s)
+        '{md5}' + Digest::MD5.hexdigest(value.to_s) # rubocop:disable Style/StringConcatenation
       end
     end
 
-    def is_to_s(value) # rubocop:disable Style/PredicateName
+    def is_to_s(value) # rubocop:disable Naming/PredicateName
       if @resource[:show_diff]
-        ":\n" + value
+        ":\n" + value # rubocop:disable Style/StringConcatenation
       else
-        '{md5}' + Digest::MD5.hexdigest(value.to_s)
+        '{md5}' + Digest::MD5.hexdigest(value.to_s) # rubocop:disable Style/StringConcatenation
       end
     end
   end
@@ -82,6 +76,8 @@ Puppet::Type.newtype(:powerdns_zone_private) do
   autorequire(:service) do
     ['pdns']
   end
+  # rubocop:disable Lint/EmptyBlock
   autorequire(:powerdns_zone) do
   end
+  # rubocop:enable Lint/EmptyBlock
 end

--- a/lib/puppet/type/powerdns_zone_private.rb
+++ b/lib/puppet/type/powerdns_zone_private.rb
@@ -1,0 +1,87 @@
+# private resource which collected all the records through powerdns_zone
+Puppet::Type.newtype(:powerdns_zone_private) do
+  @doc = 'ensure a zone exists. This is a private class do NOT use it in your mannifests instead use powerdns_zone which will
+         call this resource with the zone records added.'
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  newparam(:name, namevar: true) do
+    desc 'name of the zone name as namevar'
+
+    validate do |value|
+      unless value.is_a?(String)
+        raise ArgumentError, 'The name of the zone needs to be a string'
+      end
+    end
+  end
+
+  newparam(:config_name) do
+    desc "Virtual configuration name, defaults to '' which will ignore the property."
+    defaultto ''
+
+    validate do |value|
+      unless value.is_a?(String)
+        raise ArgumentError, 'config_name needs to be a string'
+      end
+    end
+  end
+
+  newparam(:config_dir) do
+    desc 'Location of pdns.conf. Default is which will ignore the property.'
+    defaultto ''
+    validate do |value|
+      unless value.is_a?(String)
+        raise ArgumentError, 'config_dir needs to be a string'
+      end
+    end
+  end
+
+  newparam(:manage_records, boolean: true, parent: Puppet::Parameter::Boolean) do
+    desc 'if we manage the all zone records for the domain (any records not managed with puppet will be purged).'
+    defaultto :true
+  end
+
+  newparam(:show_diff, boolean: true, parent: Puppet::Parameter::Boolean) do
+    desc "Whether to display differences when the zone changes, defaulting to
+        false. Since zones can be huge, use this only for debugging"
+    defaultto :false
+  end
+
+  newproperty(:content) do
+    desc "Content (records) of the zone. This must match the output of 'pdnsutil list-zone ZONE'."
+
+    munge do |value|
+      if @resource[:manage_records]
+        ("$ORIGIN .\n" + value).to_s.gsub(%r{\n+$}, '') + "\n"
+      else
+        ''
+      end
+    end
+
+    def should_to_s(value)
+      if @resource[:show_diff]
+        ":\n" + value
+      else
+        '{md5}' + Digest::MD5.hexdigest(value.to_s)
+      end
+    end
+
+    def is_to_s(value) # rubocop:disable Style/PredicateName
+      if @resource[:show_diff]
+        ":\n" + value
+      else
+        '{md5}' + Digest::MD5.hexdigest(value.to_s)
+      end
+    end
+  end
+
+  # autorequire the powerdns class
+  autorequire(:service) do
+    ['pdns']
+  end
+  autorequire(:powerdns_zone) do
+  end
+end

--- a/manifests/authoritative.pp
+++ b/manifests/authoritative.pp
@@ -27,8 +27,9 @@ class powerdns::authoritative ($package_ensure = $powerdns::params::default_pack
     }
   }
 
-  service { $::powerdns::params::authoritative_service:
+  service { 'pdns':
     ensure   => running,
+    name     => $::powerdns::params::authoritative_service,
     enable   => true,
     provider => [$::powerdns::params::service_provider],
     require  => Package[$::powerdns::params::authoritative_package],

--- a/manifests/backends/bind.pp
+++ b/manifests/backends/bind.pp
@@ -37,7 +37,7 @@ class powerdns::backends::bind inherits powerdns {
     path    => "${::powerdns::params::authoritative_configdir}/named.conf",
     line    => "options { directory \"${::powerdns::params::authoritative_configdir}/named\"; };",
     match   => 'options',
-    notify  => Service[$::powerdns::params::authoritative_service],
+    notify  => Service['pdns'],
     require => File["${::powerdns::params::authoritative_configdir}/named.conf"],
   }
 

--- a/manifests/backends/ldap.pp
+++ b/manifests/backends/ldap.pp
@@ -56,7 +56,7 @@ class powerdns::backends::ldap ($package_ensure = $powerdns::params::default_pac
     # set up the powerdns backend
     package { $::powerdns::params::ldap_backend_package_name:
       ensure  => $package_ensure,
-      before  => Service[$::powerdns::params::authoritative_service],
+      before  => Service['pdns'],
       require => Package[$::powerdns::params::authoritative_package],
     }
   }

--- a/manifests/backends/mysql.pp
+++ b/manifests/backends/mysql.pp
@@ -47,7 +47,7 @@ class powerdns::backends::mysql ($package_ensure = $powerdns::params::default_pa
     # set up the powerdns backend
     package { $::powerdns::params::mysql_backend_package_name:
       ensure  => $package_ensure,
-      before  => Service[$::powerdns::params::authoritative_service],
+      before  => Service['pdns'],
       require => Package[$::powerdns::params::authoritative_package],
     }
   }

--- a/manifests/backends/postgresql.pp
+++ b/manifests/backends/postgresql.pp
@@ -56,7 +56,7 @@ class powerdns::backends::postgresql ($package_ensure = $powerdns::params::defau
   if $::powerdns::params::pgsql_backend_package_name {
     package { $::powerdns::params::pgsql_backend_package_name:
       ensure  => $package_ensure,
-      before  => Service[$::powerdns::params::authoritative_service],
+      before  => Service['pdns'],
       require => Package[$::powerdns::params::authoritative_package],
     }
   }

--- a/manifests/backends/sqlite.pp
+++ b/manifests/backends/sqlite.pp
@@ -19,7 +19,7 @@ class powerdns::backends::sqlite ($package_ensure = $powerdns::params::default_p
   if $::powerdns::params::sqlite_backend_package_name {
     package { $::powerdns::params::sqlite_backend_package_name:
       ensure  => $package_ensure,
-      before  => Service[$::powerdns::params::authoritative_service],
+      before  => Service['pdns'],
       require => Package[$::powerdns::params::authoritative_package],
     }
   }
@@ -46,7 +46,7 @@ class powerdns::backends::sqlite ($package_ensure = $powerdns::params::default_p
     -> exec { 'powerdns-sqlite3-create-tables':
       command => "/usr/bin/env sqlite3 ${::powerdns::db_file} < ${::powerdns::sqlite_schema_file}",
       unless  => "/usr/bin/env test `echo '.tables domains' | sqlite3 ${::powerdns::db_file} | wc -l` -eq 1",
-      before  => Service[$::powerdns::params::authoritative_service],
+      before  => Service['pdns'],
       require => Package[$::powerdns::params::authoritative_package],
     }
   }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -25,11 +25,11 @@ define powerdns::config(
   if $type == 'authoritative' {
     $path            = $::powerdns::params::authoritative_config
     $require_package = $::powerdns::params::authoritative_package
-    $notify_service  = $::powerdns::params::authoritative_service
+    $notify_service  = 'pdns'
   } else {
     $path            = $::powerdns::params::recursor_config
     $require_package = $::powerdns::params::recursor_package
-    $notify_service  = $::powerdns::params::recursor_service
+    $notify_service  = 'pdns-recursor'
   }
 
   file_line { "powerdns-config-${setting}-${path}":

--- a/manifests/recursor.pp
+++ b/manifests/recursor.pp
@@ -4,8 +4,9 @@ class powerdns::recursor ($package_ensure = $powerdns::params::default_package_e
     ensure => $package_ensure,
   }
 
-  service { $::powerdns::params::recursor_service:
+  service { 'pdns-recursor':
     ensure   => running,
+    name     => $::powerdns::params::recursor_service,
     enable   => true,
     provider => [$::powerdns::params::service_provider],
     require  => Package[$::powerdns::params::recursor_package],

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -3,10 +3,8 @@ require 'spec_helper_acceptance'
 case default['platform']
 when /debian|ubuntu/
   authoritative_config = '/etc/powerdns/pdns.conf'
-  authoritative_service = 'pdns'
 when /el|centos/
   authoritative_config = '/etc/pdns/pdns.conf'
-  authoritative_service = 'pdns'
 else
   logger.notify("Cannot manage PowerDNS on #{default['platform']}")
 end
@@ -41,7 +39,7 @@ describe 'powerdns class' do
       its(:content) { should match 'gmysql-host=localhost' }
     end
 
-    describe service(authoritative_service) do
+    describe service('pdns') do
       it { should be_running }
     end
 

--- a/spec/classes/powerdns_init_spec.rb
+++ b/spec/classes/powerdns_init_spec.rb
@@ -85,9 +85,10 @@ describe 'powerdns', type: :class do
           # Check the authoritative server
           it { is_expected.to contain_class('powerdns::authoritative') }
           it { is_expected.to contain_package(authoritative_package_name).with('ensure' => 'installed') }
-          it { is_expected.to contain_service(authoritative_service_name).with('ensure' => 'running') }
-          it { is_expected.to contain_service(authoritative_service_name).with('enable' => 'true') }
-          it { is_expected.to contain_service(authoritative_service_name).that_requires(format('Package[%<package>s]', package: authoritative_package_name)) }
+          it { is_expected.to contain_service('pdns').with('ensure' => 'running') }
+          it { is_expected.to contain_service('pdns').with('enable' => 'true') }
+          it { is_expected.to contain_service('pdns').with('name' => authoritative_service_name) }
+          it { is_expected.to contain_service('pdns').that_requires(format('Package[%<package>s]', package: authoritative_package_name)) }
         end
 
         context 'powerdns class with epel' do
@@ -384,9 +385,10 @@ describe 'powerdns', type: :class do
           # Check the authoritative server
           it { is_expected.to contain_class('powerdns::recursor') }
           it { is_expected.to contain_package(recursor_package_name).with('ensure' => 'installed') }
-          it { is_expected.to contain_service(recursor_service_name).with('ensure' => 'running') }
-          it { is_expected.to contain_service(recursor_service_name).with('enable' => 'true') }
-          it { is_expected.to contain_service(recursor_service_name).that_requires(format('Package[%<package>s]', package: recursor_package_name)) }
+          it { is_expected.to contain_service('pdns-recursor').with('ensure' => 'running') }
+          it { is_expected.to contain_service('pdns-recursor').with('enable' => 'true') }
+          it { is_expected.to contain_service('pdns-recursor').with('name' => recursor_service_name) }
+          it { is_expected.to contain_service('pdns-recursor').that_requires(format('Package[%<package>s]', package: recursor_package_name)) }
         end
 
         # Test errors

--- a/spec/defines/powerdns_config_spec.rb
+++ b/spec/defines/powerdns_config_spec.rb
@@ -28,11 +28,9 @@ describe 'powerdns::config' do
         when 'RedHat'
           authoritative_config = '/etc/pdns/pdns.conf'
           recursor_config = '/etc/pdns-recursor/recursor.conf'
-          authoritative_service_name = 'pdns'
         when 'Debian'
           authoritative_config = '/etc/powerdns/pdns.conf'
           recursor_config = '/etc/powerdns/recursor.conf'
-          authoritative_service_name = 'pdns'
         end
 
         context 'powerdns::config with parameters' do
@@ -49,7 +47,7 @@ describe 'powerdns::config' do
           it { is_expected.to contain_file_line(format('powerdns-config-foo-%<config>s', config: authoritative_config)).with_line('foo=bar') }
           it { is_expected.to contain_file_line(format('powerdns-config-foo-%<config>s', config: authoritative_config)).with_match('^foo=') }
           it { is_expected.to contain_file_line(format('powerdns-config-foo-%<config>s', config: authoritative_config)).with_match_for_absence(true) }
-          it { is_expected.to contain_file_line(format('powerdns-config-foo-%<config>s', config: authoritative_config)).that_notifies(format('Service[%<service>s]', service: authoritative_service_name)) }
+          it { is_expected.to contain_file_line(format('powerdns-config-foo-%<config>s', config: authoritative_config)).that_notifies('Service[pdns]') }
         end
 
         context 'powerdns::config with recursor type' do

--- a/spec/unit/puppet/provider/powerdns_zone_private/pdnsutil_spec.rb
+++ b/spec/unit/puppet/provider/powerdns_zone_private/pdnsutil_spec.rb
@@ -2,14 +2,13 @@
 
 require 'spec_helper'
 
-
 provider_class = Puppet::Type.type(:powerdns_zone_private).provider(:pdnsutil)
 
 describe provider_class do
   let(:resource) do
     Puppet::Type::Powerdns_zone_private.new(
       name: 'example.com',
-      provider: described_class.name,
+      provider: described_class.name
     )
   end
 

--- a/spec/unit/puppet/provider/powerdns_zone_private/pdnsutil_spec.rb
+++ b/spec/unit/puppet/provider/powerdns_zone_private/pdnsutil_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+
+provider_class = Puppet::Type.type(:powerdns_zone_private).provider(:pdnsutil)
+
+describe provider_class do
+  let(:resource) do
+    Puppet::Type::Powerdns_zone_private.new(
+      name: 'example.com',
+      provider: described_class.name,
+    )
+  end
+
+  let(:provider) { provider_class.new(resource) }
+end

--- a/spec/unit/puppet/type/powerdns_record_spec.rb
+++ b/spec/unit/puppet/type/powerdns_record_spec.rb
@@ -1,0 +1,18 @@
+require 'puppet'
+require 'puppet/type/powerdns_record'
+
+describe Puppet::Type.type(:powerdns_record) do
+  before(:each) do
+    @res = Puppet::Type.type(:powerdns_record).new(name: 'www.example.com')
+  end
+
+  it 'has its name set' do
+    expect(@res[:name]).to eq('www.example.com')
+  end
+  it 'has set target zone' do
+    expect(@res[:target_zone]).to eq('example.com')
+  end
+  it 'has set rname' do
+    expect(@res[:rname]).to eq('www')
+  end
+end

--- a/spec/unit/puppet/type/powerdns_zone_private_spec.rb
+++ b/spec/unit/puppet/type/powerdns_zone_private_spec.rb
@@ -1,0 +1,18 @@
+require 'puppet'
+require 'puppet/type/powerdns_zone_private'
+
+describe Puppet::Type.type(:powerdns_zone_private) do
+  before(:each) do
+    @res = Puppet::Type.type(:powerdns_zone_private).new(name: 'example.com')
+  end
+
+  it 'has its name set' do
+    expect(@res[:name]).to eq('example.com')
+  end
+  it 'has set config_dir to empty string' do
+    expect(@res[:config_dir]).to eq('')
+  end
+  it 'has set config_name to empty string' do
+    expect(@res[:config_name]).to eq('')
+  end
+end

--- a/spec/unit/puppet/type/powerdns_zone_spec.rb
+++ b/spec/unit/puppet/type/powerdns_zone_spec.rb
@@ -1,0 +1,18 @@
+require 'puppet'
+require 'puppet/type/powerdns_zone'
+
+describe Puppet::Type.type(:powerdns_zone) do
+  before(:each) do
+    @res = Puppet::Type.type(:powerdns_zone).new(name: 'example.com')
+  end
+
+  it 'has its name set' do
+    expect(@res[:name]).to eq('example.com')
+  end
+  it 'has set config_dir to empty string' do
+    expect(@res[:config_dir]).to eq('')
+  end
+  it 'has set config_name to empty string' do
+    expect(@res[:config_name]).to eq('')
+  end
+end


### PR DESCRIPTION
allow managing zones and records with puppet for a specific zone.
The service name change commit simplifies the autorequire dependencies.