### PR TITLE
sort pdnsutil output to avoid update on each puppet run

### DIFF
--- a/lib/puppet/provider/powerdns_zone_private/pdnsutil.rb
+++ b/lib/puppet/provider/powerdns_zone_private/pdnsutil.rb
@@ -73,7 +73,7 @@ Puppet::Type.type(:powerdns_zone_private).provide(
     soarec[-5] = '_SERIAL_'
     records[soanr] = soarec[0..3].join("\t") + "\t" + soarec[4..10].join(' ') # rubocop:disable Style/StringConcatenation
 
-    records.join("\n") + "\n" # rubocop:disable Style/StringConcatenation
+    records.sort.join("\n") + "\n" # rubocop:disable Style/StringConcatenation
   end
   # rubocop:enable Metrics/AbcSize
   # rubocop:enable Metrics/MethodLength

--- a/lib/puppet/type/powerdns_zone.rb
+++ b/lib/puppet/type/powerdns_zone.rb
@@ -140,6 +140,7 @@ Puppet::Type.newtype(:powerdns_zone) do
       end
       # rubocop:enable Style/StringConcatenation
     end
+    content.push("$ORIGIN .\n") # add this, since it's always in the output..
     content.sort.join("\n")
   end
   # rubocop:enable Metrics/AbcSize

--- a/lib/puppet/type/powerdns_zone_private.rb
+++ b/lib/puppet/type/powerdns_zone_private.rb
@@ -45,11 +45,11 @@ Puppet::Type.newtype(:powerdns_zone_private) do
   end
 
   newproperty(:content) do
-    desc "Content (records) of the zone. This must match the output of 'pdnsutil list-zone ZONE'."
+    desc "Content (records) of the zone. This must match the output of 'pdnsutil list-zone ZONE|sort'."
 
     munge do |value|
       if @resource[:manage_records]
-        ("$ORIGIN .\n" + value).to_s.gsub(/\n+$/, '') + "\n" # rubocop:disable Style/StringConcatenation
+        value.to_s.gsub(/\n+$/, '') + "\n" # rubocop:disable Style/StringConcatenation
       else
         ''
       end


### PR DESCRIPTION
In certain cases (noted on SOA and NS) records there was an update
on each puppet run. We now sort the pdnsutil output the same way
as we do for the input to avoid this problem.

This is a fix to the merge request #122