### PR TITLE
Ignore .git for pdk build

### DIFF
--- a/.pmtignore
+++ b/.pmtignore
@@ -1,1 +1,3 @@
 vendor/
+.*/
+pkg/


### PR DESCRIPTION
Inspired by https://github.com/puppetlabs/puppet-modulebuilder/blob/main/lib/puppet/modulebuilder/builder.rb#L8-L17

Fix #127