### PR TITLE
Allow passing boolean

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source ENV['GEM_SOURCE'] || 'https://rubygems.org' # rubocop:disable Style/FetchEnvVar
+source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 puppetversion = ENV.key?('PUPPET_VERSION') ? ENV['PUPPET_VERSION'] : ['~> 5.0.0']
 gem 'facter', '>= 1.7.0'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
-source ENV['GEM_SOURCE'] || 'https://rubygems.org'
+source ENV.fetch('GEM_SOURCE', 'https://rubygems.org')
 
-puppetversion = ENV.key?('PUPPET_VERSION') ? ENV['PUPPET_VERSION'] : ['~> 5.0.0']
+puppetversion = ENV.key?('PUPPET_VERSION') ? ENV.fetch('PUPPET_VERSION') : ['~> 5.0.0']
 gem 'facter', '>= 1.7.0'
 gem 'metadata-json-lint', '< 2.0.0'
 gem 'puppet', puppetversion

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,7 +1,7 @@
 # powerdns::config
 define powerdns::config(
   String                            $setting = $title,
-  Variant[String, Integer]          $value   = '',
+  Variant[String, Integer, Boolean] $value   = '',
   Enum['present', 'absent']         $ensure  = 'present',
   Enum['authoritative', 'recursor'] $type    = 'authoritative'
 ) {
@@ -14,7 +14,7 @@ define powerdns::config(
     'local-ipv6'
   ]
   unless $ensure == 'absent' or ($setting in $empty_value_allowed) {
-    assert_type(Variant[String[1], Integer], $value) |$_expected, $_actual| {
+    assert_type(Variant[String[1], Integer, Boolean], $value) |$_expected, $_actual| {
       fail("Value for ${setting} can't be empty.")
     }
   }

--- a/spec/defines/powerdns_config_spec.rb
+++ b/spec/defines/powerdns_config_spec.rb
@@ -139,13 +139,14 @@ describe 'powerdns::config' do
             {
               setting: 'webserver',
               value: true,
-              type: 'recursor',
+              type: 'recursor'
             }
           end
 
-          it { is_expected.to contain_file_line(format('powerdns-config-webserver-%<config>s',
-            config: recursor_config)
-          ).with_line('webserver=true') }
+          it {
+            is_expected.to contain_file_line(format('powerdns-config-webserver-%<config>s',
+                                                    config: recursor_config)).with_line('webserver=true')
+          }
         end
       end
     end

--- a/spec/defines/powerdns_config_spec.rb
+++ b/spec/defines/powerdns_config_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 override_facts = {
   root_home: '/root'
 }
@@ -130,6 +132,20 @@ describe 'powerdns::config' do
           it 'fails' do
             expect { subject.call }.to raise_error(/expects a match for Enum\['authoritative', 'recursor'\], got/)
           end
+        end
+
+        context 'powerdns::config with boolean' do
+          let(:params) do
+            {
+              setting: 'webserver',
+              value: true,
+              type: 'recursor',
+            }
+          end
+
+          it { is_expected.to contain_file_line(format('powerdns-config-webserver-%<config>s',
+            config: recursor_config)
+          ).with_line('webserver=true') }
         end
       end
     end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -13,7 +13,7 @@ RSpec.configure do |c|
   # Configure all nodes in nodeset
   c.before :suite do
     hosts.each do |host|
-      run_puppet_install_helper unless ENV['BEAKER_provision'] == 'no' # rubocop:disable Style/FetchEnvVar
+      run_puppet_install_helper unless ENV['BEAKER_provision'] == 'no'
 
       # Install rsync
       install_package(host, 'rsync')

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -13,7 +13,7 @@ RSpec.configure do |c|
   # Configure all nodes in nodeset
   c.before :suite do
     hosts.each do |host|
-      run_puppet_install_helper unless ENV['BEAKER_provision'] == 'no'
+      run_puppet_install_helper unless ENV.fetch('BEAKER_provision') == 'no'
 
       # Install rsync
       install_package(host, 'rsync')


### PR DESCRIPTION
Many configuration parameters have `Boolean` type. This PR allows passing booleans with no need to write them as `String`.