### PR TITLE
Support 4.7 release

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,7 +21,7 @@ class powerdns (
   Optional[String[1]]        $service_provider                   = $::powerdns::params::service_provider,
   Boolean                    $custom_repo                        = $::powerdns::params::custom_repo,
   Boolean                    $custom_epel                        = $::powerdns::params::custom_epel,
-  Pattern[/4\.(0|1|2|3|4|5|6)/] $version                         = $::powerdns::params::version,
+  Pattern[/4\.[0-7]/]        $version                            = $::powerdns::params::version,
   String[1]                  $mysql_schema_file                  = $::powerdns::params::mysql_schema_file,
   String[1]                  $pgsql_schema_file                  = $::powerdns::params::pgsql_schema_file,
 ) inherits powerdns::params {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,7 +21,7 @@ class powerdns (
   Optional[String[1]]        $service_provider                   = $::powerdns::params::service_provider,
   Boolean                    $custom_repo                        = $::powerdns::params::custom_repo,
   Boolean                    $custom_epel                        = $::powerdns::params::custom_epel,
-  Pattern[/4\.[0-7]/]        $version                            = $::powerdns::params::version,
+  Pattern[/4\.[0-9]+/]       $version                            = $::powerdns::params::version,
   String[1]                  $mysql_schema_file                  = $::powerdns::params::mysql_schema_file,
   String[1]                  $pgsql_schema_file                  = $::powerdns::params::pgsql_schema_file,
 ) inherits powerdns::params {

--- a/spec/classes/powerdns_init_spec.rb
+++ b/spec/classes/powerdns_init_spec.rb
@@ -433,6 +433,34 @@ describe 'powerdns', type: :class do
             expect { subject.call }.to raise_error(/'backend' expects a match for Enum\['bind', 'ldap', 'mysql', 'postgresql', 'sqlite'\]/)
           end
         end
+
+        context 'powerdns version 4.7' do
+          let(:params) do
+            {
+              db_root_password: 'foobar',
+              db_username: 'foo',
+              db_password: 'bar',
+              version: '4.7'
+            }
+          end
+
+          case facts[:osfamily]
+          when 'RedHat'
+            it {
+              is_expected.to contain_yumrepo('powerdns') \
+                .with('baseurl' => 'http://repo.powerdns.com/centos/$basearch/$releasever/auth-47')
+            }
+            it {
+              is_expected.to contain_yumrepo('powerdns-recursor') \
+                .with('baseurl' => 'http://repo.powerdns.com/centos/$basearch/$releasever/rec-47')
+            }
+          when 'Debian'
+            it { is_expected.to contain_apt__source('powerdns').with_release(/auth-47/) }
+            it { is_expected.to contain_apt__source('powerdns-recursor').with_release(/rec-47/) }
+          end
+
+          it { is_expected.to contain_package(authoritative_package_name).with('ensure' => 'installed') }
+        end
       end
     end
   end


### PR DESCRIPTION
At least recursor is stable in 4.7 version. Generally from maintainer's perspective I'd say it's easier to allow any version number matching certain format. Otherwise you should maintain whole compatibility matrix for all distributions and release versions which is painful :disappointed: 