### PR TITLE
Support configuration of multiple forward zones

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,24 @@ class { 'powerdns':
 }
 ```
 
+### Recursor forward zones
+
+Multiple forward zones can be configured using `powerdns::forward_zones`.
+
+```puppet
+include powerdns::recursor
+```
+
+The configuration will be serialized into `forward-zones-file` config file.
+
+```yaml
+powerdns::forward_zones:
+  'example.com': 10.0.0.1
+  'foo': 192.168.1.1
+   # recurse queries
+  '+.': 1.1.1.1;8.8.8.8;8.8.4.4
+```
+
 ### Backends
 
 The default backend is MySQL. It also comes with support for PostgreSQL, Bind,

--- a/manifests/authoritative.pp
+++ b/manifests/authoritative.pp
@@ -1,9 +1,14 @@
 # powerdns::authoritative
-class powerdns::authoritative ($package_ensure = $powerdns::params::default_package_ensure) inherits powerdns {
+class powerdns::authoritative (
+  $package_ensure = $powerdns::params::default_package_ensure,
+  Optional[Array[String]] $install_packages = $powerdns::install_packages,
+  ) inherits powerdns {
   # install the powerdns package
   package { $::powerdns::params::authoritative_package:
     ensure => $package_ensure,
   }
+
+  ensure_packages($install_packages)
 
   # install the right backend
   case $::powerdns::backend {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,8 +24,8 @@ class powerdns (
   Pattern[/4\.[0-9]+/]       $version                            = $::powerdns::params::version,
   String[1]                  $mysql_schema_file                  = $::powerdns::params::mysql_schema_file,
   String[1]                  $pgsql_schema_file                  = $::powerdns::params::pgsql_schema_file,
+  Hash                       $forward_zones                      = {},
 ) inherits powerdns::params {
-
   # Do some additional checks. In certain cases, some parameters are no longer optional.
   if $authoritative {
     if ($::powerdns::backend != 'bind') and ($::powerdns::backend != 'ldap') and ($::powerdns::backend != 'sqlite') {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -40,7 +40,9 @@ class powerdns::params {
       $authoritative_configdir = '/etc/pdns'
       $recursor_package = 'pdns-recursor'
       $recursor_service = 'pdns-recursor'
-      $recursor_config = '/etc/pdns-recursor/recursor.conf'
+      $recursor_dir = '/etc/pdns-recursor'
+      $recursor_config = "${recursor_dir}/recursor.conf"
+      $install_packages = []
     }
     'Debian': {
       $authoritative_package = 'pdns-server'
@@ -61,7 +63,34 @@ class powerdns::params {
       $authoritative_configdir = '/etc/powerdns'
       $recursor_package = 'pdns-recursor'
       $recursor_service = 'pdns-recursor'
-      $recursor_config = '/etc/powerdns/recursor.conf'
+      $recursor_dir = '/etc/powerdns'
+      $recursor_config = "${recursor_dir}/recursor.conf"
+
+      case $facts['os']['name'] {
+        'Debian': {
+          case $facts['os']['release']['major'] {
+            '8': {
+              $install_packages = []
+            }
+            default: {
+              $install_packages = ['dirmngr']
+            }
+          }
+        }
+        'Ubuntu': {
+          case $facts['os']['release']['major'] {
+            '16.04': {
+              $install_packages = []
+            }
+            default: {
+              $install_packages = ['dirmngr']
+            }
+          }
+        }
+        default: {
+          $install_packages = []
+        }
+      }
     }
     'FreeBSD': {
       $authoritative_package = 'powerdns'
@@ -82,7 +111,9 @@ class powerdns::params {
       $authoritative_configdir = '/usr/local/etc/pdns'
       $recursor_package = 'powerdns-recursor'
       $recursor_service = 'pdns-recursor'
-      $recursor_config = '/usr/local/etc/pdns/recursor.conf'
+      $recursor_dir = '/usr/local/etc/pdns'
+      $recursor_config = "${recursor_dir}/recursor.conf"
+      $install_packages = []
     }
     default: {
       fail("${facts['os']['family']} is not supported yet.")

--- a/manifests/recursor.pp
+++ b/manifests/recursor.pp
@@ -1,14 +1,41 @@
-# the powerdns recursor
-class powerdns::recursor ($package_ensure = $powerdns::params::default_package_ensure) inherits powerdns {
-  package { $::powerdns::params::recursor_package:
+# @summary powerdns recursor
+
+# @param package_ensure
+# @param forward_zones
+#   Hash containing zone => dns servers pairs
+# @param recursor_dir
+#   Configuration directory for recursor
+#
+class powerdns::recursor (
+  String $package_ensure = $powerdns::params::default_package_ensure,
+  Hash   $forward_zones  = $powerdns::forward_zones,
+  String $recursor_dir   = $powerdns::recursor_dir,
+) inherits powerdns {
+  package { $powerdns::recursor_package:
     ensure => $package_ensure,
+  }
+
+  if !empty($forward_zones) {
+    $zone_config = "${recursor_dir}/forward_zones.conf"
+    file { $zone_config:
+      ensure  => file,
+      owner   => 'root',
+      group   => 'root',
+      content => template('powerdns/forward_zones.conf.erb'),
+      notify  => Service['pdns-recursor'],
+    }
+
+    powerdns::config { 'forward-zones-file':
+      value => $zone_config,
+      type  => 'recursor',
+    }
   }
 
   service { 'pdns-recursor':
     ensure   => running,
-    name     => $::powerdns::params::recursor_service,
+    name     => $powerdns::params::recursor_service,
     enable   => true,
-    provider => [$::powerdns::params::service_provider],
-    require  => Package[$::powerdns::params::recursor_package],
+    provider => [$powerdns::params::service_provider],
+    require  => Package[$powerdns::params::recursor_package],
   }
 }

--- a/templates/forward_zones.conf.erb
+++ b/templates/forward_zones.conf.erb
@@ -1,0 +1,4 @@
+<% @forward_zones.sort.each do |key, value| -%>
+<%= key %>=<%= value %>
+<% end -%>
+


### PR DESCRIPTION
Forward zones configuration is a bit messy when too many domains are on a single line:

```
forward-zones=example.org=203.0.113.210, powerdns.com=2001:DB8::BEEF:5
```
this PR adds possibility to zones as a hash:

```yaml
powerdns::forward_zones:
  example.org: 203.0.113.210
  powerdns.com: 2001:DB8::BEEF:5
``` 