### PR TITLE
Drop unneeded service_provider name

### DIFF
--- a/manifests/authoritative.pp
+++ b/manifests/authoritative.pp
@@ -36,7 +36,6 @@ class powerdns::authoritative (
     ensure   => running,
     name     => $::powerdns::params::authoritative_service,
     enable   => true,
-    provider => [$::powerdns::params::service_provider],
     require  => Package[$::powerdns::params::authoritative_package],
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,7 +18,6 @@ class powerdns (
   String[1]                  $ldap_method                        = 'strict',
   Optional[String[1]]        $ldap_binddn                        = undef,
   Optional[String[1]]        $ldap_secret                        = undef,
-  String[1]                  $service_provider                   = $::powerdns::params::service_provider,
   Boolean                    $custom_repo                        = false,
   Boolean                    $custom_epel                        = false,
   Pattern[/4\.[0-9]+/]       $version                            = $::powerdns::params::version,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,7 +13,6 @@ class powerdns::params {
       $mysql_backend_package_name = 'pdns-backend-mysql'
       $ldap_backend_package_name = 'pdns-backend-ldap'
       $pgsql_backend_package_name = 'pdns-backend-postgresql'
-      $service_provider = 'systemd'
       $sqlite_backend_package_name = 'pdns-backend-sqlite'
       $mysql_schema_file = '/usr/share/doc/pdns-backend-mysql-4.?.?/schema.mysql.sql'
       $pgsql_schema_file = '/usr/share/doc/pdns-backend-postgresql-4.?.?/schema.pgsql.sql'
@@ -38,7 +37,6 @@ class powerdns::params {
       $sqlite_backend_package_name = 'pdns-backend-sqlite3'
       $mysql_schema_file = '/usr/share/doc/pdns-backend-mysql/schema.mysql.sql'
       $pgsql_schema_file = '/usr/share/doc/pdns-backend-pgsql/schema.pgsql.sql'
-      $service_provider = 'systemd'
       $sqlite_schema_file = '/usr/share/doc/pdns-backend-sqlite3/schema.sqlite3.sql'
       $sqlite_package_name = 'sqlite3'
       $authoritative_configdir = '/etc/powerdns'
@@ -85,7 +83,6 @@ class powerdns::params {
       $sqlite_backend_package_name = undef
       $mysql_schema_file = '/usr/local/share/doc/powerdns/schema.mysql.sql'
       $pgsql_schema_file = '/usr/local/share/doc/powerdns/schema.pgsql.sql'
-      $service_provider = 'freebsd'
       $sqlite_schema_file = '/usr/local/share/doc/powerdns/schema.sqlite3.sql'
       $sqlite_package_name = 'sqlite3'
       $authoritative_configdir = '/usr/local/etc/pdns'

--- a/manifests/recursor.pp
+++ b/manifests/recursor.pp
@@ -35,7 +35,6 @@ class powerdns::recursor (
     ensure   => running,
     name     => $powerdns::params::recursor_service,
     enable   => true,
-    provider => [$powerdns::params::service_provider],
     require  => Package[$powerdns::params::recursor_package],
   }
 }


### PR DESCRIPTION
Puppet will figure out the provider on it's own. It's not required to configure it. Cleaning this up will make it easier to implement new operating systems.