### PR TITLE
mysql::db sql parameter changed to array

### DIFF
--- a/manifests/backends/mysql.pp
+++ b/manifests/backends/mysql.pp
@@ -72,7 +72,7 @@ class powerdns::backends::mysql ($package_ensure = $powerdns::params::default_pa
       password => $::powerdns::db_password,
       host     => $::powerdns::db_host,
       grant    => [ 'ALL' ],
-      sql      => $::powerdns::mysql_schema_file,
+      sql      => [ $::powerdns::mysql_schema_file ],
       require  => Package[$::powerdns::params::mysql_backend_package_name],
     }
   }

--- a/spec/classes/powerdns_init_spec.rb
+++ b/spec/classes/powerdns_init_spec.rb
@@ -175,7 +175,7 @@ describe 'powerdns', type: :class do
           it { is_expected.to contain_class('powerdns::backends::mysql') }
           it { is_expected.to contain_package('pdns-backend-mysql').with('ensure' => 'installed') }
           it { is_expected.to contain_mysql__db('powerdns').with('user' => 'foo', 'password' => 'bar', 'host' => '127.0.0.1') }
-          it { is_expected.to contain_mysql__db('powerdns').with_sql(mysql_schema_file) }
+          it { is_expected.to contain_mysql__db('powerdns').with_sql([ mysql_schema_file ]) }
 
           # This sets our configuration
           it { is_expected.to contain_powerdns__config('gmysql-host').with('value' => '127.0.0.1') }


### PR DESCRIPTION
As of Mysql module 13.0.0 mysql::db sql parameter can only be an array