### PR TITLE
Support Sensitive strings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
+        rubygems: 3.2.3
 
     - name: Rubocop
       run: bundle exec rake rubocop

--- a/README.md
+++ b/README.md
@@ -161,7 +161,11 @@ The zone records can be managed through the powerdns\_record resource. As an exa
    rcontent    => '127.0.0.1'
  }
 ```
-Remark: if the target\_zone is not managed with powerdns\_zone resource, powerdns\_record does not change anything !
+Remark: if the target\_zone is not managed with powerdns\_zone resource, powerdns\_record does not change anything!
+
+### Sensitive secrets
+
+Passwords can be passed either as plain-text strings or as [Puppet's Sensitive type](https://www.puppet.com/docs/puppet/7/lang_data_sensitive.html) when appropriate encrypted backend is configured on Puppet server.
 
 ## Reference
 
@@ -200,7 +204,7 @@ Defaults to true.
 ##### `db_root_password`
 
 If you set `backend_install` to true you are asked to specify a root
-password for your database.
+password for your database. Accepts either `String` or `Sensitive` type.
 
 ##### `db_username`
 
@@ -208,7 +212,7 @@ Set the database username. Defaults to 'powerdns'.
 
 ##### `db_password`
 
-Set the database password. Default is empty.
+Set the database password. Accepts either `String` or `Sensitive` type. Default is empty.
 
 ##### `db_name`
 
@@ -245,7 +249,7 @@ Path to the object to authenticate against. Defaults to undef.
 
 ##### `ldap_secret`
 
-Password for simple authentication against ldap_basedn. Defaults to undef.
+Password for simple authentication against ldap_basedn. Accepts either `String` or `Sensitive` type. Defaults to undef.
 
 ##### `custom_repo`
 

--- a/manifests/backends/ldap.pp
+++ b/manifests/backends/ldap.pp
@@ -31,10 +31,15 @@ class powerdns::backends::ldap ($package_ensure = $powerdns::params::default_pac
     type    => 'authoritative',
   }
 
+  $_ldap_secret = $::powerdns::ldap_secret =~ Sensitive ? {
+    true => $::powerdns::ldap_secret.unwrap,
+    false => $::powerdns::ldap_secret
+  }
+
   powerdns::config { 'ldap-secret':
     ensure  => present,
     setting => 'ldap-secret',
-    value   => $::powerdns::ldap_secret,
+    value   => $_ldap_secret,
     type    => 'authoritative',
   }
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -14,7 +14,7 @@ define powerdns::config(
     'local-ipv6'
   ]
   unless $ensure == 'absent' or ($setting in $empty_value_allowed) {
-    assert_type(Variant[String[1], Integer, Boolean, Sensitive[String]], $value) |$_expected, $_actual| {
+    assert_type(Variant[String[1], Integer, Boolean, Sensitive[String[1]]], $value) |$_expected, $_actual| {
       fail("Value for ${setting} can't be empty.")
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,9 +5,9 @@ class powerdns (
   Enum['ldap', 'mysql', 'bind', 'postgresql', 'sqlite'] $backend = 'mysql',
   Boolean                    $backend_install                    = true,
   Boolean                    $backend_create_tables              = true,
-  Optional[String[1]]        $db_root_password                   = undef,
+  Powerdns::Secret           $db_root_password                   = undef,
   String[1]                  $db_username                        = 'powerdns',
-  Optional[String[1]]        $db_password                        = undef,
+  Powerdns::Secret           $db_password                        = undef,
   String[1]                  $db_name                            = 'powerdns',
   String[1]                  $db_host                            = 'localhost',
   Integer[1]                 $db_port                            = 3306,
@@ -18,7 +18,7 @@ class powerdns (
   Optional[String[1]]        $ldap_basedn                        = undef,
   String[1]                  $ldap_method                        = 'strict',
   Optional[String[1]]        $ldap_binddn                        = undef,
-  Optional[String[1]]        $ldap_secret                        = undef,
+  Powerdns::Secret           $ldap_secret                        = undef,
   Boolean                    $custom_repo                        = false,
   Boolean                    $custom_epel                        = false,
   Pattern[/4\.[0-9]+/]       $version                            = $::powerdns::params::version,
@@ -29,17 +29,17 @@ class powerdns (
   # Do some additional checks. In certain cases, some parameters are no longer optional.
   if $authoritative {
     if ($::powerdns::backend != 'bind') and ($::powerdns::backend != 'ldap') and ($::powerdns::backend != 'sqlite') and $require_db_password {
-      assert_type(String[1], $db_password) |$expected, $actual| {
+      assert_type(Variant[String[1], Sensitive[String[1]]], $db_password) |$expected, $actual| {
         fail("'db_password' must be a non-empty string when 'authoritative' == true")
       }
       if $backend_install {
-        assert_type(String[1], $db_root_password) |$expected, $actual| {
+        assert_type(Variant[String[1], Sensitive[String[1]]], $db_root_password) |$expected, $actual| {
           fail("'db_root_password' must be a non-empty string when 'backend_install' == true")
         }
       }
     }
     if $backend_create_tables and $backend == 'mysql' {
-      assert_type(String[1], $db_root_password) |$expected, $actual| {
+      assert_type(Variant[String[1], Sensitive[String[1]]], $db_root_password) |$expected, $actual| {
         fail("On MySQL 'db_root_password' must be a non-empty string when 'backend_create_tables' == true")
       }
     }

--- a/spec/classes/powerdns_init_spec.rb
+++ b/spec/classes/powerdns_init_spec.rb
@@ -423,6 +423,35 @@ describe 'powerdns', type: :class do
           it { is_expected.not_to contain_powerdns__backends__mysql__create_table('tsigkeys') }
         end
 
+        context 'powerdns with mysql backend and Sensitive password' do
+          let(:params) do
+            {
+              db_root_password: 'foobar',
+              db_username: 'foo',
+              db_password: sensitive('TopSecret'),
+              backend: 'mysql',
+              backend_create_tables: true
+            }
+          end
+
+          it { is_expected.to contain_mysql__db('powerdns').with('user' => 'foo', 'password' => 'TopSecret', 'host' => 'localhost') }
+        end
+
+        context 'powerdns with postgresql backend and Sensitive password' do
+          let(:params) do
+            {
+              db_root_password: 'foobar',
+              db_username: 'foo',
+              db_password: sensitive('TopSecret'),
+              backend: 'postgresql',
+              backend_create_tables: true
+            }
+          end
+
+          it { is_expected.to contain_powerdns__config('gpgsql-password').with(value: 'TopSecret') }
+          it { is_expected.to contain_postgresql__server__db('powerdns').with('user' => 'foo') }
+        end
+
         # Test the recursor
         context 'powerdns class with the recursor enabled and the authoritative server disabled' do
           let(:params) do

--- a/spec/classes/powerdns_init_spec.rb
+++ b/spec/classes/powerdns_init_spec.rb
@@ -365,6 +365,21 @@ describe 'powerdns', type: :class do
             it { is_expected.to contain_file_line('powerdns-config-ldap-method-%{config}' % { config: authoritative_config }) }
           end
 
+          context 'with Sensitive password' do
+            let(:params) do
+              {
+                ldap_basedn: 'ou=foo',
+                ldap_binddn: 'foo',
+                ldap_secret: sensitive('secret_bar'),
+                backend: 'ldap',
+                backend_install: false,
+                backend_create_tables: false
+              }
+            end
+
+            it { is_expected.to contain_powerdns__config('ldap-secret').with('value' => 'secret_bar') }
+          end
+
           context 'with backend_install set to true' do
             let(:params) do
               {

--- a/spec/defines/powerdns_config_spec.rb
+++ b/spec/defines/powerdns_config_spec.rb
@@ -149,6 +149,20 @@ describe 'powerdns::config' do
             is_expected.to contain_file_line('powerdns-config-webserver-%{config}' % { config: recursor_config }).with_line('webserver=true')
           }
         end
+
+        context 'powerdns::config with Sensitive' do
+          let(:params) do
+            {
+              setting: 'webserver-password',
+              value: sensitive('S3cr3t'),
+              type: 'recursor'
+            }
+          end
+
+          it {
+            is_expected.to contain_file_line('powerdns-config-webserver-password-%{config}' % { config: recursor_config }).with_line('webserver-password=S3cr3t')
+          }
+        end
       end
     end
   end

--- a/types/configvalue.pp
+++ b/types/configvalue.pp
@@ -1,0 +1,7 @@
+type Powerdns::ConfigValue = Variant[
+                               String,
+                               Integer,
+                               Boolean,
+                               Sensitive[String[1]]
+                             ]
+

--- a/types/secret.pp
+++ b/types/secret.pp
@@ -1,0 +1,6 @@
+type Powerdns::Secret = Optional[
+                          Variant[
+                            String[1],
+                            Sensitive[String[1]]
+                          ]
+                        ]


### PR DESCRIPTION
This PR adds support secrets passed as [Sensitive](https://www.puppet.com/docs/puppet/7/lang_data_sensitive.html) data type.