### PR TITLE
Allow postgresql 10 module

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppetlabs/postgresql",
-      "version_requirement": ">= 9.1.0 < 10.0.0"
+      "version_requirement": ">= 9.1.0 < 11.0.0"
     },
     {
       "name": "puppetlabs/apt",


### PR DESCRIPTION
Allow `puppetlabs/postgresql` versions `10.0.x`