### PR TITLE
Fix should_content not correctly matching pdnsutil output

### DIFF
--- a/lib/puppet/type/powerdns_zone.rb
+++ b/lib/puppet/type/powerdns_zone.rb
@@ -136,11 +136,11 @@ Puppet::Type.newtype(:powerdns_zone) do
       if r[:rname] == '.'
         content.push([r[:target_zone], r[:rttl], r[:rclass], r[:rtype], r[:rcontent]].join("\t"))
       else
-        content.push([r[:rname] + '.' + r[:target_zone], r[:rttl], r[:rclass], r[:rtype], r[:rcontent]].join("\t"))
+        content.push([(r[:rname] + '.' + r[:target_zone]).downcase, r[:rttl], r[:rclass], r[:rtype], r[:rcontent]].join("\t"))
       end
       # rubocop:enable Style/StringConcatenation
     end
-    content.push("$ORIGIN .\n") # add this, since it's always in the output..
+    content.push("$ORIGIN .") # add this, since it's always in the output..
     content.sort.join("\n")
   end
   # rubocop:enable Metrics/AbcSize


### PR DESCRIPTION
This fixes two bugs when comparing zone contents to pdnsutil output, which triggers the continual re-import of managed zones:
- an extraneous `\n` after `$ORIGIN .` which causes `\n\n` to be added to the resultant zone after record sort;
- `rname` values being included in a case-sensitive manner, when records are always returned as downcase, which means that uppercase characters in `rname` parameters cause zones to always be re-imported.

Changing the relevant lines in `should_content` ensures that affected zones are only re-imported when records actually differ.

No test changes are included as `powerdns_zone` contents do not currently have any tests running against them.