### PR TITLE
Add lmdb backend option

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ powerdns::forward_zones:
 ### Backends
 
 The default backend is MySQL. It also comes with support for PostgreSQL, Bind,
-LDAP and SQLite.
+LDAP, SQLite and lmdb.
 
 If you don't specify the backend it assumes you will use MySQL.
 
@@ -115,6 +115,16 @@ has write permissions to directory holding database file. For example:
 class { 'powerdns':
   backend => 'sqlite',
   db_file => '/opt/powerdns.sqlite3',
+}
+```
+To use lmdb you must set `backend_install` and `backend_create_tables` to
+false. For example:
+
+```puppet
+class { 'powerdns':
+  backend               => 'lmdb',
+  backend_install       => false,
+  backend_create_tables => false,
 }
 ```
 
@@ -265,6 +275,22 @@ Path to the object to authenticate against. Defaults to undef.
 ##### `ldap_secret`
 
 Password for simple authentication against ldap_basedn. Accepts either `String` or `Sensitive` type. Defaults to undef.
+
+##### `lmdb_filename`
+
+The file where database will be stored when using LMDB backend. Defaults to '/var/lib/powerdns/powerdns.lmdb'
+
+##### `lmdb_schema_version`
+
+The schema version to use when creating the LMDB database. Defaults to undef, using the powerdns default.
+
+##### `lmdb_shards`
+
+The number of shards to use when creating the LMDB database. Defaults to undef, using the powerdns default.
+
+##### `lmdb_sync_mode`
+
+The sync mode to use when creating the LMDB database. Defaults to undef, using the powerdns default.
 
 ##### `custom_repo`
 

--- a/manifests/authoritative.pp
+++ b/manifests/authoritative.pp
@@ -10,27 +10,20 @@ class powerdns::authoritative (
 
   stdlib::ensure_packages($install_packages)
 
-  # install the right backend
-  case $powerdns::backend {
-    'mysql': {
-      include powerdns::backends::mysql
-    }
-    'bind': {
-      include powerdns::backends::bind
-    }
-    'postgresql': {
-      include powerdns::backends::postgresql
-    }
-    'ldap': {
-      include powerdns::backends::ldap
-    }
-    'sqlite': {
-      include powerdns::backends::sqlite
-    }
-    default: {
-      fail("${powerdns::backend} is not supported. We only support 'mysql', 'bind', 'postgresql', 'ldap' and 'sqlite' at the moment.")
-    }
+  $supported_backends = [
+    'mysql',
+    'bind',
+    'postgresql',
+    'ldap',
+    'sqlite',
+    'lmdb',
+  ]
+
+  unless $powerdns::backend in $supported_backends {
+    fail("${powerdns::backend} is not supported. We only support ${supported_backends.join(', ')} at the moment.")
   }
+
+  include "powerdns::backends::${powerdns::backend}"
 
   service { 'pdns':
     ensure  => running,

--- a/manifests/backends/lmdb.pp
+++ b/manifests/backends/lmdb.pp
@@ -1,0 +1,54 @@
+# lmdb backend for powerdns
+class powerdns::backends::lmdb (
+  $package_ensure = $powerdns::params::default_package_ensure
+) inherits powerdns {
+  if $facts['os']['family'] == 'Debian' {
+    # The pdns-server package from the Debian APT repo automatically installs the bind
+    # backend package which we do not want when using another backend such as ldap.
+    package { 'pdns-backend-bind':
+      ensure  => purged,
+      require => Package[$powerdns::params::authoritative_package],
+    }
+
+    # The pdns-backend-lmdb package installs a configuration file that conflicts with this module's backend configuration.
+    file { "${powerdns::params::authoritative_configdir}/pdns.d/lmdb.conf":
+      ensure  => absent,
+      require => Package[$powerdns::params::lmdb_backend_package_name],
+      before  => Service['pdns'],
+    }
+  }
+
+  $options = {
+    'launch'              => 'lmdb',
+    'lmdb-filename'       => $powerdns::lmdb_filename,
+    'lmdb-schema-version' => $powerdns::lmdb_schema_version,
+    'lmdb-shards'         => $powerdns::lmdb_shards,
+    'lmdb-sync-mode'      => $powerdns::lmdb_sync_mode,
+  }.delete_undef_values()
+
+  $options.each |$key, $value| {
+    powerdns::config { $key:
+      ensure  => present,
+      setting => $key,
+      value   => $value,
+      type    => 'authoritative',
+    }
+  }
+
+  if $powerdns::params::lmdb_backend_package_name {
+    # set up the powerdns backend
+    package { $powerdns::params::lmdb_backend_package_name:
+      ensure  => $package_ensure,
+      before  => Service['pdns'],
+      require => Package[$powerdns::params::authoritative_package],
+    }
+  }
+
+  if $powerdns::backend_install {
+    fail('backend_install is not supported with lmdb')
+  }
+
+  if $powerdns::backend_create_tables {
+    fail('backend_create_tables is not supported with lmdb')
+  }
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -27,6 +27,7 @@ class powerdns::params {
       $ldap_backend_package_name = 'pdns-backend-ldap'
       $pgsql_backend_package_name = 'pdns-backend-postgresql'
       $sqlite_backend_package_name = 'pdns-backend-sqlite'
+      $lmdb_backend_package_name = 'pdns-backend-lmdb'
       $sqlite_package_name = 'sqlite'
       $authoritative_configdir = '/etc/pdns'
       $recursor_package = 'pdns-recursor'
@@ -45,6 +46,7 @@ class powerdns::params {
       $ldap_backend_package_name = 'pdns-backend-ldap'
       $pgsql_backend_package_name = 'pdns-backend-pgsql'
       $sqlite_backend_package_name = 'pdns-backend-sqlite3'
+      $lmdb_backend_package_name = 'pdns-backend-lmdb'
       $mysql_schema_file = '/usr/share/doc/pdns-backend-mysql/schema.mysql.sql'
       $pgsql_schema_file = '/usr/share/doc/pdns-backend-pgsql/schema.pgsql.sql'
       $sqlite_schema_file = '/usr/share/doc/pdns-backend-sqlite3/schema.sqlite3.sql'
@@ -91,6 +93,7 @@ class powerdns::params {
       $ldap_backend_package_name = undef
       $pgsql_backend_package_name = undef
       $sqlite_backend_package_name = undef
+      $lmdb_backend_package_name = undef
       $mysql_schema_file = '/usr/local/share/doc/powerdns/schema.mysql.sql'
       $pgsql_schema_file = '/usr/local/share/doc/powerdns/schema.pgsql.sql'
       $sqlite_schema_file = '/usr/local/share/doc/powerdns/schema.sqlite3.sql'
@@ -118,6 +121,7 @@ class powerdns::params {
       $ldap_backend_package_name = undef
       $pgsql_backend_package_name = undef
       $sqlite_backend_package_name = undef
+      $lmdb_backend_package_name = undef
       $authoritative_config = '/etc/powerdns/pdns.conf'
       $recursor_dir = '/etc/powerdns'
       $recursor_config = "${recursor_dir}/recursor.conf"

--- a/spec/classes/powerdns_init_spec.rb
+++ b/spec/classes/powerdns_init_spec.rb
@@ -497,7 +497,6 @@ describe 'powerdns', type: :class do
           end
         end
 
-
         context 'powerdns class with backend_create_tables set to false' do
           let(:params) do
             {


### PR DESCRIPTION
This PR adds support for the lmdb backend of pdns. I have conformed to the "params" method of supplying configuration options, to let it blend in with the rest.