### PR TITLE
fix regex to get repo version

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -2,8 +2,8 @@
 class powerdns::repo inherits powerdns {
   # The repositories of PowerDNS use a version such as '40' for version 4.0
   # and 41 for version 4.1.
-  $authoritative_short_version = regsubst($powerdns::authoritative_version, /^(\d)\.(\d)$/, '\\1\\2', 'G')
-  $recursor_short_version = regsubst($powerdns::recursor_version, /^(\d)\.(\d)$/, '\\1\\2', 'G')
+  $authoritative_short_version = regsubst($powerdns::authoritative_version, /^(\d+)\.(\d+)(?:\.\d+)?$/, '\\1\\2', 'G')
+  $recursor_short_version = regsubst($powerdns::recursor_version, /^(\d+)\.(\d+)(?:\.\d+)?$/, '\\1\\2', 'G')
 
   case $facts['os']['family'] {
     'RedHat': {


### PR DESCRIPTION
The current regex to get the short repo version isn't matching correctly. This PR fixes the issue.

See https://regex101.com/r/dRrY85/1 for more details.