### PR TITLE
drop db_dir parameter

### DIFF
--- a/data/os/Archlinux.yaml
+++ b/data/os/Archlinux.yaml
@@ -1,6 +1,5 @@
 ---
-powerdns::db_dir: /var/lib/powerdns
-powerdns::db_file: "%{lookup('powerdns::db_dir')}/powerdns.sqlite3"
+powerdns::db_file: "/var/lib/powerdns/powerdns.sqlite3"
 powerdns::mysql_schema_file: /usr/share/doc/powerdns/schema.mysql.sql
 powerdns::pgsql_schema_file: /usr/share/doc/powerdns/schema.pgsql.sql
 powerdns::sqlite_schema_file: /usr/share/doc/powerdns/schema.sqlite3.sql

--- a/data/os/Debian.yaml
+++ b/data/os/Debian.yaml
@@ -1,6 +1,5 @@
 ---
-powerdns::db_dir: /var/lib/powerdns
-powerdns::db_file: "%{lookup('powerdns::db_dir')}/powerdns.sqlite3"
+powerdns::db_file: "/var/lib/powerdns/powerdns.sqlite3"
 powerdns::mysql_schema_file: /usr/share/doc/pdns-backend-mysql/schema.mysql.sql
 powerdns::pgsql_schema_file: /usr/share/doc/pdns-backend-pgsql/schema.pgsql.sql
 powerdns::sqlite_schema_file: /usr/share/doc/pdns-backend-sqlite3/schema.sqlite3.sql

--- a/data/os/FreeBSD.yaml
+++ b/data/os/FreeBSD.yaml
@@ -1,6 +1,5 @@
 ---
-powerdns::db_dir: /var/db/powerdns
-powerdns::db_file: "%{lookup('powerdns::db_dir')}/powerdns.sqlite3"
+powerdns::db_file: "/var/db/powerdns/powerdns.sqlite3"
 powerdns::mysql_schema_file: /usr/local/share/doc/powerdns/schema.mysql.sql
 powerdns::pgsql_schema_file: /usr/local/share/doc/powerdns/schema.pgsql.sql
 powerdns::sqlite_schema_file: /usr/local/share/doc/powerdns/schema.sqlite3.sql

--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -1,6 +1,5 @@
 ---
-powerdns::db_dir: /var/lib/powerdns
-powerdns::db_file: "%{lookup('powerdns::db_dir')}/powerdns.sqlite3"
+powerdns::db_file: "/var/lib/powerdns/powerdns.sqlite3"
 powerdns::mysql_schema_file: /usr/share/doc/pdns-backend-mysql/schema.mysql.sql
 powerdns::pgsql_schema_file: /usr/share/doc/pdns-backend-postgresql/schema.pgsql.sql
 powerdns::sqlite_schema_file: /usr/share/doc/pdns-backend-sqlite/schema.sqlite.sql

--- a/manifests/backends/sqlite.pp
+++ b/manifests/backends/sqlite.pp
@@ -32,7 +32,7 @@ class powerdns::backends::sqlite (
     }
   }
   if $powerdns::backend_create_tables {
-    file { $powerdns::db_dir:
+    file { dirname($powerdns::db_file):
       ensure  => directory,
       mode    => '0755',
       owner   => 'pdns',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,7 +25,6 @@ class powerdns (
   Stdlib::Absolutepath $authoritative_configdir,
   Stdlib::Absolutepath $authoritative_config,
   Pattern[/4\.[0-9]+/] $authoritative_version,
-  Stdlib::Absolutepath $db_dir,
   Stdlib::Absolutepath $db_file,
   Stdlib::Absolutepath $mysql_schema_file,
   Stdlib::Absolutepath $pgsql_schema_file,


### PR DESCRIPTION
The module is currently managing the directory specified in `powerdns::db_dir` and is, by default, part of the `powerdns::db_file` parameter:

```
powerdns::db_dir: /var/lib/powerdns
powerdns::db_file: "%{lookup('powerdns::db_dir')}/powerdns.sqlite3"
```

With the following config, the module is managing a directory, but the db file resides in a completely different directory:
```puppet
class { 'powerdns':
  db_dir => '/srv/somedir',
  db_file => '/srv/anotherdir/powerdns.sqlite3'
}
```

This PR drops the `db_dir` parameter and uses `basename(db_file)` instead, to manage the direct parent dir of the database file.