### PR TITLE
Drop puppet, update openvox minimum version to 8.19

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -100,7 +100,6 @@ The following parameters are available in the `powerdns` class:
 * [`autoprimaries`](#-powerdns--autoprimaries)
 * [`purge_autoprimaries`](#-powerdns--purge_autoprimaries)
 * [`authoritative_group`](#-powerdns--authoritative_group)
-* [`db_dir`](#-powerdns--db_dir)
 
 ##### <a name="-powerdns--authoritative_package_name"></a>`authoritative_package_name`
 
@@ -490,12 +489,6 @@ Data type: `String[1]`
 This group will be set on authoritative server files.
 
 Default value: `'pdns'`
-
-##### <a name="-powerdns--db_dir"></a>`db_dir`
-
-Data type: `Stdlib::Absolutepath`
-
-
 
 ### <a name="powerdns--authoritative"></a>`powerdns::authoritative`
 

--- a/metadata.json
+++ b/metadata.json
@@ -66,12 +66,8 @@
   ],
   "requirements": [
     {
-      "name": "puppet",
-      "version_requirement": ">= 7.0.0 < 9.0.0"
-    },
-    {
       "name": "openvox",
-      "version_requirement": ">= 7.0.0 < 9.0.0"
+      "version_requirement": ">= 8.19.0 < 9.0.0"
     }
   ],
   "tags": [


### PR DESCRIPTION
* drop support for puppet as discussed in [1]
* update openvox minimum version to 8.19.0 as discussed in [2] and [3]

[1] https://github.com/voxpupuli/community-triage/issues/59
[2] https://github.com/voxpupuli/community-triage/issues/60
[3] https://github.com/voxpupuli/modulesync_config/pull/978#discussion_r2232830327
