### PR TITLE
Support authoritative 5.x version (#230)

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -152,7 +152,7 @@ Authoritative config file path
 
 ##### <a name="-powerdns--authoritative_version"></a>`authoritative_version`
 
-Data type: `Pattern[/4\.[0-9]+/]`
+Data type: `Pattern[/[4,5]\.[0-9]+/]`
 
 Authoritative server version
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -152,7 +152,7 @@ Authoritative config file path
 
 ##### <a name="-powerdns--authoritative_version"></a>`authoritative_version`
 
-Data type: `Pattern[/[4,5]\.[0-9]+/]`
+Data type: `Pattern[/[45]\.[0-9]+/]`
 
 Authoritative server version
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -132,7 +132,7 @@ class powerdns (
   String[1] $authoritative_service_name,
   Stdlib::Absolutepath $authoritative_configdir,
   Stdlib::Absolutepath $authoritative_config,
-  Pattern[/4\.[0-9]+/] $authoritative_version,
+  Pattern[/[4,5]\.[0-9]+/] $authoritative_version,
   Stdlib::Absolutepath $db_file,
   Stdlib::Absolutepath $mysql_schema_file,
   Stdlib::Absolutepath $pgsql_schema_file,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -132,7 +132,7 @@ class powerdns (
   String[1] $authoritative_service_name,
   Stdlib::Absolutepath $authoritative_configdir,
   Stdlib::Absolutepath $authoritative_config,
-  Pattern[/[4,5]\.[0-9]+/] $authoritative_version,
+  Pattern[/[45]\.[0-9]+/] $authoritative_version,
   Stdlib::Absolutepath $db_file,
   Stdlib::Absolutepath $mysql_schema_file,
   Stdlib::Absolutepath $pgsql_schema_file,

--- a/spec/classes/powerdns_init_spec.rb
+++ b/spec/classes/powerdns_init_spec.rb
@@ -632,6 +632,36 @@ describe 'powerdns', type: :class do
           it { is_expected.to contain_package(authoritative_package_name).with('ensure' => 'installed') }
         end
 
+        context 'powerdns version 5' do
+          let(:params) do
+            {
+              db_root_password: 'foobar',
+              db_username: 'foo',
+              db_password: 'bar',
+              authoritative_version: '5.0',
+              recursor_version: '5.3'
+            }
+          end
+
+          case facts[:os]['family']
+          when 'RedHat'
+            it {
+              is_expected.to contain_yumrepo('powerdns').
+                with('baseurl' => 'http://repo.powerdns.com/centos/$basearch/$releasever/auth-50')
+            }
+
+            it {
+              is_expected.to contain_yumrepo('powerdns-recursor').
+                with('baseurl' => 'http://repo.powerdns.com/centos/$basearch/$releasever/rec-53')
+            }
+          when 'Debian'
+            it { is_expected.to contain_apt__source('powerdns').with_release(%r{auth-50}) }
+            it { is_expected.to contain_apt__source('powerdns-recursor').with_release(%r{rec-53}) }
+          end
+
+          it { is_expected.to contain_package(authoritative_package_name).with('ensure' => 'installed') }
+        end
+
         context 'powerdns class with the recursor with forward zones' do
           let(:params) do
             {

--- a/spec/classes/powerdns_init_spec.rb
+++ b/spec/classes/powerdns_init_spec.rb
@@ -639,20 +639,20 @@ describe 'powerdns', type: :class do
               db_username: 'foo',
               db_password: 'bar',
               authoritative_version: '5.0',
-              recursor_version: '5.3'
+              recursor_version: '5.3',
             }
           end
 
           case facts[:os]['family']
           when 'RedHat'
             it {
-              is_expected.to contain_yumrepo('powerdns').
-                with('baseurl' => 'http://repo.powerdns.com/centos/$basearch/$releasever/auth-50')
+              is_expected.to contain_yumrepo('powerdns')
+                .with('baseurl' => 'http://repo.powerdns.com/centos/$basearch/$releasever/auth-50')
             }
 
             it {
-              is_expected.to contain_yumrepo('powerdns-recursor').
-                with('baseurl' => 'http://repo.powerdns.com/centos/$basearch/$releasever/rec-53')
+              is_expected.to contain_yumrepo('powerdns-recursor')
+                .with('baseurl' => 'http://repo.powerdns.com/centos/$basearch/$releasever/rec-53')
             }
           when 'Debian'
             it { is_expected.to contain_apt__source('powerdns').with_release(%r{auth-50}) }


### PR DESCRIPTION
#### Pull Request (PR) description

Support 4.x and 5.x releases for auth (and recursor as well).

#### This Pull Request (PR) fixes the following issues
 - Fixes #230

