### PR TITLE
Add support for YAML config

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,29 @@ class { 'powerdns':
   recursor         => true,
 }
 ```
+### YAML config format
+
+Starting from Recursor `5.0` YAML syntax is supported. From release `5.2` `recursor.conf` file is parsed as YAML, unless `--enable-old-settings` flag is provided. The old configuration can be converted:
+
+```
+$ rec_control show-yaml path/to/recursor.conf
+```
+
+For detailed changes in syntax see [the official documentation](https://doc.powerdns.com/recursor/appendices/yamlconversion.html).
+```yaml
+powerdns::recursor_version: '5.3'
+powerdns::recursor_use_yaml: true
+powerdns::recursor::config:
+  dnssec:
+    validation: 'off'
+  incoming:
+    allow_from:
+      - 0.0.0.0/0
+    distributor_threads: 1
+    listen:
+      - 0.0.0.0:53
+```
+
 
 ### Recursor forward zones
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -19,7 +19,8 @@
 
 ### Defined types
 
-* [`powerdns::config`](#powerdns--config): Manage powerdns settings
+* [`powerdns::config`](#powerdns--config): Manage powerdns settings in old configuration format.
+Supported up to recursor version 5.2.
 
 ### Resource types
 
@@ -107,6 +108,9 @@ The following parameters are available in the `powerdns` class:
 * [`authoritative_group`](#-powerdns--authoritative_group)
 * [`authoritative_file_owner`](#-powerdns--authoritative_file_owner)
 * [`authoritative_file_group`](#-powerdns--authoritative_file_group)
+* [`recursor_use_yaml`](#-powerdns--recursor_use_yaml)
+* [`recursor_local_config_file`](#-powerdns--recursor_local_config_file)
+* [`recursor_local_config`](#-powerdns--recursor_local_config)
 
 ##### <a name="-powerdns--authoritative_package_name"></a>`authoritative_package_name`
 
@@ -156,7 +160,7 @@ Authoritative config file path
 
 ##### <a name="-powerdns--authoritative_version"></a>`authoritative_version`
 
-Data type: `Pattern[/4\.[0-9]+/]`
+Data type: `Pattern[/[4,5]\.[0-9]+/]`
 
 Authoritative server version
 
@@ -509,11 +513,11 @@ Default value: `false`
 
 ##### <a name="-powerdns--forward_zones"></a>`forward_zones`
 
-Data type: `Hash`
+Data type: `Optional[Variant[Hash,Tuple]]`
 
 Configures recursor forward_zones
 
-Default value: `{}`
+Default value: `undef`
 
 ##### <a name="-powerdns--autoprimaries"></a>`autoprimaries`
 
@@ -563,6 +567,30 @@ Group of authoritative config files
 
 Default value: `$authoritative_group`
 
+##### <a name="-powerdns--recursor_use_yaml"></a>`recursor_use_yaml`
+
+Data type: `Boolean`
+
+
+
+Default value: `false`
+
+##### <a name="-powerdns--recursor_local_config_file"></a>`recursor_local_config_file`
+
+Data type: `Optional[Stdlib::Absolutepath]`
+
+
+
+Default value: `undef`
+
+##### <a name="-powerdns--recursor_local_config"></a>`recursor_local_config`
+
+Data type: `Optional[Hash]`
+
+
+
+Default value: `undef`
+
 ### <a name="powerdns--authoritative"></a>`powerdns::authoritative`
 
 powerdns::authoritative
@@ -595,19 +623,59 @@ sqlite backend for powerdns
 
 powerdns recursor
 
+* **See also**
+  * https://doc.powerdns.com/recursor/yamlsettings.html
+
 #### Parameters
 
 The following parameters are available in the `powerdns::recursor` class:
 
 * [`forward_zones`](#-powerdns--recursor--forward_zones)
+* [`config`](#-powerdns--recursor--config)
+* [`forward_zones_file`](#-powerdns--recursor--forward_zones_file)
+* [`include`](#-powerdns--recursor--include)
+* [`config_includedir`](#-powerdns--recursor--config_includedir)
 
 ##### <a name="-powerdns--recursor--forward_zones"></a>`forward_zones`
 
-Data type: `Hash`
+Data type: `Optional[Variant[Hash,Tuple]]`
 
 Hash containing zone => dns servers pairs
 
 Default value: `$powerdns::forward_zones`
+
+##### <a name="-powerdns--recursor--config"></a>`config`
+
+Data type: `Hash`
+
+recursor config (will be converted to YAML)
+when powerdns::recursor_use_yaml is set to `true`
+
+Default value: `{}`
+
+##### <a name="-powerdns--recursor--forward_zones_file"></a>`forward_zones_file`
+
+Data type: `String`
+
+filename (without extension)
+
+Default value: `'forward_zones'`
+
+##### <a name="-powerdns--recursor--include"></a>`include`
+
+Data type: `Hash`
+
+Key as filename and its contents as value
+
+Default value: `{}`
+
+##### <a name="-powerdns--recursor--config_includedir"></a>`config_includedir`
+
+Data type: `Stdlib::Absolutepath`
+
+
+
+Default value: `"${powerdns::recursor_configdir}/recursor.d"`
 
 ### <a name="powerdns--repo"></a>`powerdns::repo`
 
@@ -617,7 +685,11 @@ powerdns::repo
 
 ### <a name="powerdns--config"></a>`powerdns::config`
 
-Manage powerdns settings
+Manage powerdns settings in old configuration format.
+Supported up to recursor version 5.2.
+
+* **See also**
+  * https://doc.powerdns.com/recursor/settings.html
 
 #### Parameters
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,4 +1,7 @@
 ---
+lookup_options:
+  powerdns::recursor_local_config:
+    merge: deep
 powerdns::authoritative_package_ensure: installed
 powerdns::authoritative_extra_packages_ensure: installed
 powerdns::authoritative_version: '4.9'
@@ -8,3 +11,4 @@ powerdns::recursor_user: pdns
 powerdns::recursor_group: pdns
 powerdns::recursor_file_owner: root
 powerdns::recursor_file_group: "%{lookup('powerdns::recursor_group')}"
+powerdns::recursor_use_yaml: false

--- a/data/os/Debian.yaml
+++ b/data/os/Debian.yaml
@@ -1,5 +1,5 @@
 ---
-powerdns::db_file: "/var/lib/powerdns/powerdns.sqlite3"
+powerdns::db_file: /var/lib/powerdns/powerdns.sqlite3
 powerdns::mysql_schema_file: /usr/share/doc/pdns-backend-mysql/schema.mysql.sql
 powerdns::pgsql_schema_file: /usr/share/doc/pdns-backend-pgsql/schema.pgsql.sql
 powerdns::sqlite_schema_file: /usr/share/doc/pdns-backend-sqlite3/schema.sqlite3.sql

--- a/data/os/Debian/12.yaml
+++ b/data/os/Debian/12.yaml
@@ -1,0 +1,3 @@
+---
+powerdns::mysql_charset: utf8mb3
+powerdns::mysql_collate: utf8mb3_general_ci

--- a/data/os/FreeBSD.yaml
+++ b/data/os/FreeBSD.yaml
@@ -1,5 +1,5 @@
 ---
-powerdns::db_file: "/var/db/powerdns/powerdns.sqlite3"
+powerdns::db_file: /var/db/powerdns/powerdns.sqlite3
 powerdns::mysql_schema_file: /usr/local/share/doc/powerdns/schema.mysql.sql
 powerdns::pgsql_schema_file: /usr/local/share/doc/powerdns/schema.pgsql.sql
 powerdns::sqlite_schema_file: /usr/local/share/doc/powerdns/schema.sqlite3.sql

--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -1,5 +1,5 @@
 ---
-powerdns::db_file: "/var/lib/powerdns/powerdns.sqlite3"
+powerdns::db_file: /var/lib/powerdns/powerdns.sqlite3
 powerdns::mysql_schema_file: /usr/share/doc/pdns-backend-mysql/schema.mysql.sql
 powerdns::pgsql_schema_file: /usr/share/doc/pdns-backend-postgresql/schema.pgsql.sql
 powerdns::sqlite_schema_file: /usr/share/doc/pdns-backend-sqlite/schema.sqlite.sql

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,4 +1,6 @@
-# @summary Manage powerdns settings
+# @summary Manage powerdns settings in old configuration format.
+#   Supported up to recursor version 5.2.
+# @see https://doc.powerdns.com/recursor/settings.html
 #
 # @param setting
 #   The setting you want to change

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -132,7 +132,7 @@ class powerdns (
   String[1] $authoritative_service_name,
   Stdlib::Absolutepath $authoritative_configdir,
   Stdlib::Absolutepath $authoritative_config,
-  Pattern[/4\.[0-9]+/] $authoritative_version,
+  Pattern[/[4,5]\.[0-9]+/] $authoritative_version,
   Stdlib::Absolutepath $db_file,
   Stdlib::Absolutepath $mysql_schema_file,
   Stdlib::Absolutepath $pgsql_schema_file,
@@ -157,6 +157,9 @@ class powerdns (
   Optional[String[1]] $mysql_collate = undef,
   Boolean $authoritative = true,
   Boolean $recursor = false,
+  Boolean $recursor_use_yaml = false,
+  Optional[Stdlib::Absolutepath] $recursor_local_config_file = undef,
+  Optional[Hash] $recursor_local_config = undef,
   Powerdns::Backends $backend = 'mysql',
   Boolean $backend_install = true,
   Boolean $backend_create_tables = true,
@@ -178,7 +181,7 @@ class powerdns (
   Powerdns::LmdbSyncMode $lmdb_sync_mode = undef,
   Boolean $custom_repo = false,
   Boolean $custom_epel = false,
-  Hash $forward_zones = {},
+  Optional[Variant[Hash,Tuple]] $forward_zones = undef,
   Powerdns::Autoprimaries $autoprimaries = {},
   Boolean $purge_autoprimaries = false,
   String[1] $authoritative_user = 'pdns',
@@ -223,10 +226,12 @@ class powerdns (
   if $recursor {
     contain powerdns::recursor
 
-    # Set up Hiera for the recursor.
-    $powerdns_recursor_config = lookup('powerdns::recursor::config', Hash, 'deep', {})
-    $powerdns_recursor_defaults = { 'type' => 'recursor' }
-    create_resources(powerdns::config, $powerdns_recursor_config, $powerdns_recursor_defaults)
+    # old config format
+    unless $recursor_use_yaml {
+      $powerdns_recursor_config = lookup('powerdns::recursor::config', Hash, 'deep', {})
+      $powerdns_recursor_defaults = { 'type' => 'recursor' }
+      create_resources(powerdns::config, $powerdns_recursor_config, $powerdns_recursor_defaults)
+    }
   }
 
   if $purge_autoprimaries {

--- a/manifests/recursor.pp
+++ b/manifests/recursor.pp
@@ -2,37 +2,98 @@
 #
 # @param forward_zones
 #   Hash containing zone => dns servers pairs
+# @param config recursor config (will be converted to YAML)
+#   when powerdns::recursor_use_yaml is set to `true`
+# @see https://doc.powerdns.com/recursor/yamlsettings.html
+# @param forward_zones_file filename (without extension)
+# @param include Key as filename and its contents as value
 #
 class powerdns::recursor (
-  Hash $forward_zones = $powerdns::forward_zones,
+  Optional[Variant[Hash,Tuple]] $forward_zones = $powerdns::forward_zones,
+  Hash $config = {},
+  String $forward_zones_file = 'forward_zones',
+  Stdlib::Absolutepath $config_includedir = "${powerdns::recursor_configdir}/recursor.d",
+  Hash $include = {},
 ) inherits powerdns {
   package { $powerdns::recursor_package_name:
     ensure => $powerdns::recursor_package_ensure,
   }
 
-  file { $powerdns::recursor_config:
-    ensure  => file,
-    owner   => $powerdns::recursor_file_owner,
-    group   => $powerdns::recursor_file_group,
-    require => Package[$powerdns::recursor_package_name],
-  }
+  if $powerdns::recursor_use_yaml {
+    $zone_config = "${powerdns::recursor_configdir}/${forward_zones_file}.yml"
+    ## Use New YAML based configuration
+    $forward_block = empty($forward_zones) ? {
+      true  => {},
+      false => { 'forward_zones_file' => $zone_config },
+    }
 
-  if !empty($forward_zones) {
-    $zone_config = "${powerdns::recursor_configdir}/forward_zones.conf"
+    $recursor_config = deep_merge({
+      'recursor' => {
+        'include_dir' => $config_includedir,
+      } + $forward_block,
+    }, $config)
+
+    file { $config_includedir:
+      ensure  => directory,
+      owner   => $powerdns::recursor_file_owner,
+      group   => $powerdns::recursor_file_group,
+      require => Package[$powerdns::recursor_package_name],
+    }
+
     file { $zone_config:
       ensure  => file,
       owner   => $powerdns::recursor_file_owner,
       group   => $powerdns::recursor_file_group,
-      content => template('powerdns/forward_zones.conf.erb'),
+      content => stdlib::to_yaml($forward_zones),
+      require => Package[$powerdns::recursor_package_name],
       notify  => Service['pdns-recursor'],
     }
 
-    powerdns::config { 'forward-zones-file':
-      value => $zone_config,
-      type  => 'recursor',
+    file { $powerdns::recursor_config:
+      ensure  => file,
+      owner   => $powerdns::recursor_file_owner,
+      group   => $powerdns::recursor_file_group,
+      content => stdlib::to_yaml($recursor_config),
+      require => Package[$powerdns::recursor_package_name],
+      notify  => Service['pdns-recursor'],
+    }
+
+    $include.each |String $filename, Hash $content| {
+      file { "${config_includedir}/${filename}":
+        ensure  => file,
+        owner   => $powerdns::recursor_file_owner,
+        group   => $powerdns::recursor_file_group,
+        content => stdlib::to_yaml($content),
+        require => Package[$powerdns::recursor_package_name],
+        notify  => Service['pdns-recursor'],
+      }
+    }
+  } else {
+    ## Use Old INI based configuration
+    $zone_config = "${powerdns::recursor_configdir}/${forward_zones_file}.conf"
+
+    file { $powerdns::recursor_config:
+      ensure  => file,
+      owner   => $powerdns::recursor_file_owner,
+      group   => $powerdns::recursor_file_group,
+      require => Package[$powerdns::recursor_package_name],
+    }
+
+    if !empty($forward_zones) {
+      file { $zone_config:
+        ensure  => file,
+        owner   => $powerdns::recursor_file_owner,
+        group   => $powerdns::recursor_file_group,
+        content => template('powerdns/forward_zones.conf.erb'),
+        notify  => Service['pdns-recursor'],
+      }
+
+      powerdns::config { 'forward-zones-file':
+        value => $zone_config,
+        type  => 'recursor',
+      }
     }
   }
-
   service { 'pdns-recursor':
     ensure  => running,
     name    => $powerdns::recursor_service_name,

--- a/metadata.json
+++ b/metadata.json
@@ -51,16 +51,16 @@
       ]
     },
     {
-      "operatingsystem": "Ubuntu",
-      "operatingsystemrelease": [
-        "24.04"
-      ]
-    },
-    {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "11",
         "12"
+      ]
+    },
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "24.04"
       ]
     }
   ],

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -46,7 +46,7 @@ describe 'powerdns class' do
     end
 
     describe command('/usr/bin/pdns_control version') do
-      its(:stdout) { is_expected.to match %r{^4\.9} }
+      its(:stdout) { is_expected.to match %r{^(4\.9|5\.\d)} }
     end
   end
 

--- a/spec/classes/powerdns_init_spec.rb
+++ b/spec/classes/powerdns_init_spec.rb
@@ -27,6 +27,7 @@ describe 'powerdns', type: :class do
           sqlite_binary_package_name = 'sqlite'
           recursor_package_name = 'pdns-recursor'
           recursor_service_name = 'pdns-recursor'
+          recursor_dir = '/etc/pdns-recursor'
         when 'Debian'
           authoritative_package_name = 'pdns-server'
           authoritative_service_name = 'pdns'
@@ -39,6 +40,7 @@ describe 'powerdns', type: :class do
           sqlite_binary_package_name = 'sqlite3'
           recursor_package_name = 'pdns-recursor'
           recursor_service_name = 'pdns-recursor'
+          recursor_dir = '/etc/powerdns'
         when 'Archlinux'
           authoritative_package_name = 'powerdns'
           authoritative_service_name = 'pdns'
@@ -121,9 +123,7 @@ describe 'powerdns', type: :class do
             it { is_expected.to contain_apt__keyring('powerdns.asc') }
             it { is_expected.to contain_apt__pin('powerdns') }
             it { is_expected.to contain_apt__source('powerdns') }
-            it { is_expected.to contain_apt__source('powerdns').with_release(%r{auth-49}) }
             it { is_expected.to contain_apt__source('powerdns-recursor') }
-            it { is_expected.to contain_apt__source('powerdns-recursor').with_release(%r{rec-50}) }
             it { is_expected.to contain_package('dirmngr') }
           end
 
@@ -632,11 +632,98 @@ describe 'powerdns', type: :class do
           it { is_expected.to contain_package(authoritative_package_name).with('ensure' => 'installed') }
         end
 
+        # if a yaml OS, test the yaml style forward zones
+        context 'powerdns class with the recursor with yaml forward zones' do
+          let(:params) do
+            {
+              recursor: true,
+              authoritative: false,
+              recursor_version: '5.3',
+              recursor_use_yaml: true,
+              forward_zones: [
+                {
+                  'zone'       => 'example.com',
+                  'forwarders' => ['192.0.2.1:5300'],
+                },
+                {
+                  'zone'       => 'example.net',
+                  'forwarders' => ['198.51.100.1', '198.51.100.2', '198.51.100.3', '198.51.100.4'],
+                  'recurse'    => true,
+                },
+                {
+                  'zone'       => 'example.org',
+                  'forwarders' => ['203.0.113.5', '203.0.113.6'],
+                },
+                {
+                  'zone'       => '2.0.192.in-addr.arpa',        # reverse for 192.0.2.0/24
+                  'forwarders' => ['192.0.2.53', '192.0.2.54'],
+                  'recurse'    => true,
+                },
+                {
+                  'zone'       => '100.51.198.in-addr.arpa',     # reverse for 198.51.100.0/24
+                  'forwarders' => ['198.51.100.53', '198.51.100.54'],
+                  'recurse'    => true,
+                },
+              ],
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+
+          # Check forward zones
+          it { is_expected.to contain_class('powerdns::recursor') }
+
+          it 'renders forward zones yaml correctly' do
+            is_expected.to contain_file("#{recursor_dir}/recursor.conf").with('ensure' => 'file')
+                                                                        .with_content(<<~EOS,
+                                                                          ---
+                                                                          recursor:
+                                                                            include_dir: "#{recursor_dir}/recursor.d"
+                                                                            forward_zones_file: "#{recursor_dir}/forward_zones.yml"
+                                                                        EOS
+                                                                                     )
+          end
+
+          it 'includes forward_zones config in yaml format' do
+            is_expected.to contain_file("#{recursor_dir}/forward_zones.yml").with('ensure' => 'file')
+                                                                            .with_content(<<~EOS,
+                                                                              ---
+                                                                              - zone: example.com
+                                                                                forwarders:
+                                                                                - 192.0.2.1:5300
+                                                                              - zone: example.net
+                                                                                forwarders:
+                                                                                - 198.51.100.1
+                                                                                - 198.51.100.2
+                                                                                - 198.51.100.3
+                                                                                - 198.51.100.4
+                                                                                recurse: true
+                                                                              - zone: example.org
+                                                                                forwarders:
+                                                                                - 203.0.113.5
+                                                                                - 203.0.113.6
+                                                                              - zone: 2.0.192.in-addr.arpa
+                                                                                forwarders:
+                                                                                - 192.0.2.53
+                                                                                - 192.0.2.54
+                                                                                recurse: true
+                                                                              - zone: 100.51.198.in-addr.arpa
+                                                                                forwarders:
+                                                                                - 198.51.100.53
+                                                                                - 198.51.100.54
+                                                                                recurse: true
+                                                                            EOS
+                                                                                         )
+          end
+        end
+
+        # if not a yaml OS, test the old style forward zones
         context 'powerdns class with the recursor with forward zones' do
           let(:params) do
             {
               recursor: true,
               authoritative: false,
+              recursor_version: '4.9', # without yaml support
               forward_zones: {
                 'example.com': '1.1.1.1',
                 '+.': '8.8.8.8',
@@ -644,16 +731,9 @@ describe 'powerdns', type: :class do
             }
           end
 
-          case facts[:os]['family']
-          when 'RedHat'
-            recursor_dir = '/etc/pdns-recursor'
-          when 'Debian'
-            recursor_dir = '/etc/powerdns'
-          end
-
           it { is_expected.to compile.with_all_deps }
 
-          # Check the authoritative server
+          # Check forward zones
           it { is_expected.to contain_class('powerdns::recursor') }
           it { is_expected.to contain_file("#{recursor_dir}/forward_zones.conf").with_ensure('file') }
 

--- a/spec/classes/powerdns_recursor_spec.rb
+++ b/spec/classes/powerdns_recursor_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'powerdns::recursor' do
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os}" do
+        let(:pre_condition) do
+          <<-EOS
+            class { 'powerdns':
+              db_root_password => 'foobar',
+              db_username => 'foo',
+              db_password => 'bar',
+              recursor_use_yaml => true,
+            }
+          EOS
+        end
+        let(:facts) do
+          facts
+        end
+
+        recursor_dir = case facts[:os]['family']
+                       when 'RedHat'
+                         '/etc/pdns-recursor'
+                       else
+                         '/etc/powerdns'
+                       end
+
+        it { is_expected.to compile.with_all_deps }
+
+        context 'custom config' do
+          let(:params) do
+            {
+              include: {
+                '00-defaults.yml': {
+                  logging: {
+                    loglevel: 6,
+                  },
+                },
+              },
+            }
+          end
+
+          it 'checks file resource based on hiera value' do
+            is_expected.to contain_file("#{recursor_dir}/recursor.d/00-defaults.yml").with('ensure' => 'file')
+          end
+        end
+
+        context 'with forward zones' do
+          let(:params) do
+            {
+              config: {
+                recursor: {
+                  threads: 2,
+                },
+              },
+              forward_zones_file: 'forward_zones',
+              forward_zones: [
+                {
+                  'zone'       => '.',
+                  'forwarders' => ['1.1.1.1'],
+                  'recurse'    => true,
+                },
+              ],
+            }
+          end
+
+          it 'includes main config in yaml format' do
+            is_expected.to contain_file("#{recursor_dir}/recursor.conf").with('ensure' => 'file')
+                                                                        .with_content(<<~EOS,
+                                                                          ---
+                                                                          recursor:
+                                                                            include_dir: "#{recursor_dir}/recursor.d"
+                                                                            forward_zones_file: "#{recursor_dir}/forward_zones.yml"
+                                                                            threads: 2
+                                                                        EOS
+                                                                                     )
+          end
+
+          it 'includes forward_zones config in yaml format' do
+            is_expected.to contain_file("#{recursor_dir}/forward_zones.yml").with('ensure' => 'file')
+                                                                            .with_content(<<~EOS,
+                                                                              ---
+                                                                              - zone: "."
+                                                                                forwarders:
+                                                                                - 1.1.1.1
+                                                                                recurse: true
+                                                                            EOS
+                                                                                         )
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/classes/powerdns_recursor_spec.rb
+++ b/spec/classes/powerdns_recursor_spec.rb
@@ -20,12 +20,14 @@ describe 'powerdns::recursor' do
           facts
         end
 
-        recursor_dir = case facts[:os]['family']
-                       when 'RedHat'
-                         '/etc/pdns-recursor'
-                       else
-                         '/etc/powerdns'
-                       end
+        let(:recursor_dir) do
+          case facts[:os]['family']
+          when 'RedHat'
+            '/etc/pdns-recursor'
+          else
+            '/etc/powerdns'
+          end
+        end
 
         it { is_expected.to compile.with_all_deps }
 

--- a/spec/defines/powerdns_config_spec.rb
+++ b/spec/defines/powerdns_config_spec.rb
@@ -5,6 +5,7 @@ override_facts = {
 }
 
 require 'spec_helper'
+
 describe 'powerdns::config' do
   context 'supported operating systems' do
     on_supported_os.each do |os, facts|
@@ -18,11 +19,14 @@ describe 'powerdns::config' do
         end
 
         let(:pre_condition) do
-          'class { "::powerdns":
+          'class { "powerdns":
             db_root_password => "foobar",
             db_username => "foo",
             db_password => "bar",
             recursor => true,
+            recursor_use_yaml => false,  # <- force INI mode
+            authoritative_version => "4.9",
+            recursor_version => "5.0",
           }'
         end
 
@@ -53,15 +57,12 @@ describe 'powerdns::config' do
         end
 
         context 'powerdns::config with recursor type' do
-          let(:params) do
-            {
-              setting: 'foo',
-              value: 'bar',
-              type: 'recursor',
-            }
-          end
+          let(:params) { { setting: 'foo', value: 'bar', type: 'recursor' } }
 
-          it { is_expected.to contain_file_line(format('powerdns-config-foo-%{config}', config: recursor_config)) }
+          it do
+            # Only assert in INI mode
+            is_expected.to contain_file_line("powerdns-config-foo-#{recursor_config}") unless catalogue.resource('Class', 'Powerdns')[:recursor_use_yaml]
+          end
         end
 
         context 'powerdns::config with integers' do

--- a/spec/defines/powerdns_config_yaml_spec.rb
+++ b/spec/defines/powerdns_config_yaml_spec.rb
@@ -22,24 +22,36 @@ describe 'powerdns::config', type: :define do
       end
       let(:title) { 'foo' }
 
-      case facts[:os]['family']
-      when 'RedHat'
-        authoritative_config = '/etc/pdns/pdns.conf'
-        recursor_dir = '/etc/pdns-recursor'
-      else
-        authoritative_config = '/etc/powerdns/pdns.conf'
-        recursor_dir = '/etc/powerdns'
+      let(:config_paths) do
+        recursor_dir = case facts[:os]['family']
+                       when 'RedHat'
+                         '/etc/pdns-recursor'
+                       else
+                         '/etc/powerdns'
+                       end
+
+        authoritative_config = case facts[:os]['family']
+                               when 'RedHat'
+                                 '/etc/pdns/pdns.conf'
+                               else
+                                 '/etc/powerdns/pdns.conf'
+                               end
+
+        {
+          authoritative_config: authoritative_config,
+          recursor_dir: recursor_dir,
+          recursor_config: "#{recursor_dir}/recursor.conf",
+        }
       end
-      recursor_config = "#{recursor_dir}/recursor.conf"
 
       context 'recursor type uses YAML file (with include_dir stanza)' do
         let(:params) { { setting: 'foo', value: 'bar', type: 'recursor' } }
 
-        it { is_expected.to contain_file(recursor_config).with_ensure('file') }
+        it { is_expected.to contain_file(config_paths[:recursor_config]).with_ensure('file') }
 
         it 'includes the include_dir stanza in the YAML content' do
-          is_expected.to contain_file(recursor_config)
-            .with_content(%r{include_dir:\s*"?#{Regexp.escape(recursor_dir)}/recursor\.d"?})
+          is_expected.to contain_file(config_paths[:recursor_config])
+            .with_content(%r{include_dir:\s*"?#{Regexp.escape(config_paths[:recursor_dir])}/recursor\.d"?})
         end
       end
 
@@ -47,8 +59,8 @@ describe 'powerdns::config', type: :define do
         let(:params) { { setting: 'foo', value: 'bar' } }
 
         it do
-          is_expected.to contain_file_line("powerdns-config-foo-#{authoritative_config}")
-            .with_path(authoritative_config)
+          is_expected.to contain_file_line("powerdns-config-foo-#{config_paths[:authoritative_config]}")
+            .with_path(config_paths[:authoritative_config])
         end
       end
     end

--- a/spec/defines/powerdns_config_yaml_spec.rb
+++ b/spec/defines/powerdns_config_yaml_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'powerdns::config', type: :define do
+  on_supported_os.each do |os, facts|
+    context "on #{os} with recursor_use_yaml => true" do
+      let(:facts) { facts.merge(root_home: '/root') }
+      let(:pre_condition) do
+        <<-PUPPET
+        class { 'powerdns':
+          authoritative         => true,
+          recursor              => true,
+          authoritative_version => '5.0',
+          recursor_version      => '5.3',
+          recursor_use_yaml     => true,
+          db_root_password      => 'rootpass',
+          db_username           => 'pdns',
+          db_password           => 'secret',
+        }
+        PUPPET
+      end
+      let(:title) { 'foo' }
+
+      case facts[:os]['family']
+      when 'RedHat'
+        authoritative_config = '/etc/pdns/pdns.conf'
+        recursor_dir = '/etc/pdns-recursor'
+      else
+        authoritative_config = '/etc/powerdns/pdns.conf'
+        recursor_dir = '/etc/powerdns'
+      end
+      recursor_config = "#{recursor_dir}/recursor.conf"
+
+      context 'recursor type uses YAML file (with include_dir stanza)' do
+        let(:params) { { setting: 'foo', value: 'bar', type: 'recursor' } }
+
+        it { is_expected.to contain_file(recursor_config).with_ensure('file') }
+
+        it 'includes the include_dir stanza in the YAML content' do
+          is_expected.to contain_file(recursor_config)
+            .with_content(%r{include_dir:\s*"?#{Regexp.escape(recursor_dir)}/recursor\.d"?})
+        end
+      end
+
+      context 'authoritative still writes to pdns.conf via file_line' do
+        let(:params) { { setting: 'foo', value: 'bar' } }
+
+        it do
+          is_expected.to contain_file_line("powerdns-config-foo-#{authoritative_config}")
+            .with_path(authoritative_config)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### Pull Request (PR) description

Powerdns supports [yaml config](https://doc.powerdns.com/recursor/yamlsettings.html) since version `5.0`.  Since `5.2` the default `recursor.conf` will be parsed as YAML unless `--enable-old-settings` flag is provided (which this module currently doesn't support) or `recursor.yml` config exists. This is rather a breaking change (on powerdns side).

Upgrading the old config, e.g.:
```yaml
powerdns::forward_zones:
  '+.': 1.1.1.1;8.8.8.8;8.8.4.4
powerdns::recursor::config:
  allow-from:
    value: 0.0.0.0/0
  distributor-threads:
    value: 1
  dnssec:
    value: 'off'
  local-address:
    value: 0.0.0.0:53
  log-common-errors:
    value: true
  threads:
    value: 2
```
requires non-trivial changes, but can be generated using `rec_control show-yaml` if you upgraded to at least `5.0` release first.
```yaml
powerdns::recursor_version: '5.3'
powerdns::recursor_use_yaml: true
powerdns::forward_zones:
  - zone: .
    forwarders:
      - 1.1.1.1
      - 8.8.8.8
      - 8.8.4.4
    recurse: true
powerdns::recursor::config:
  incoming:
    allow_from:
      - 0.0.0.0/0
    distributor_threads: 1
    listen:
      - 0.0.0.0:53
  logging:
    common_errors: true
    trace: fail
  recursor:
    forward_zones_file: /etc/powerdns/forward_zones.conf
    threads: 2
```

The PR replaces old configs by "new" YAML configs with `.conf` extensions by default. This might be confusing, but keeping both files would be even more confusing, considering that both configs would be parsed by the Recursor (`recursor.yml` takes precedence, if exists).

Just iterating on @peelman work done in #226. Debian 13 currently requires more work, will be done in separate PR.

#### This Pull Request (PR) fixes the following issues

Fixes #172 
