### PR TITLE
Replace deprecated `create_resources()` with native puppet

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -216,8 +216,11 @@ class powerdns (
     # Set up Hiera. Even though it's not necessary to explicitly set $type for the authoritative
     # config, it is added for clarity.
     $powerdns_auth_config = lookup('powerdns::auth::config', Hash, 'deep', {})
-    $powerdns_auth_defaults = { 'type' => 'authoritative' }
-    create_resources(powerdns::config, $powerdns_auth_config, $powerdns_auth_defaults)
+    $powerdns_auth_config.each |$conf_title, $data| {
+      powerdns::config { $conf_title:
+        * => $data + { 'type' => 'authoritative' },
+      }
+    }
   }
 
   if $recursor {
@@ -225,8 +228,11 @@ class powerdns (
 
     # Set up Hiera for the recursor.
     $powerdns_recursor_config = lookup('powerdns::recursor::config', Hash, 'deep', {})
-    $powerdns_recursor_defaults = { 'type' => 'recursor' }
-    create_resources(powerdns::config, $powerdns_recursor_config, $powerdns_recursor_defaults)
+    $powerdns_recursor_config.each| $conf_title, $data| {
+      powerdns::config { $conf_title:
+        * => $data + { 'type' => 'recursor' },
+      }
+    }
   }
 
   if $purge_autoprimaries {
@@ -234,5 +240,9 @@ class powerdns (
       purge => true,
     }
   }
-  create_resources('powerdns_autoprimary', $autoprimaries)
+  $autoprimaries.each |$primary, $data| {
+    powerdns_autoprimary { $primary:
+      * => $data,
+    }
+  }
 }


### PR DESCRIPTION
create_resources() is a legacy pattern. It messes with the ordering in the catalog. We can replace it with native puppet code.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
